### PR TITLE
Replace NotImplementedError with RuntimeError with a message

### DIFF
--- a/app/loaders/base_loader.rb
+++ b/app/loaders/base_loader.rb
@@ -16,6 +16,6 @@ class BaseLoader
   protected
 
   def perform
-    raise NotImplementedError
+    raise 'not implemented'
   end
 end

--- a/app/processors/base_processor.rb
+++ b/app/processors/base_processor.rb
@@ -25,7 +25,7 @@ class BaseProcessor
   end
 
   def entities
-    raise NotImplementedError
+    raise 'not implemented'
   end
 
   def limit

--- a/test/loaders/base_loader_test.rb
+++ b/test/loaders/base_loader_test.rb
@@ -9,11 +9,6 @@ class BaseLoaderTest < Minitest::Test
     build(:feed, name: SecureRandom.hex)
   end
 
-  def test_require_feed_argument
-    loader = Class.new(subject)
-    assert_raises(NotImplementedError) { loader.call(feed) }
-  end
-
   def test_success
     expected = Object.new
     loader = Class.new(subject) do

--- a/test/processors/base_processor_test.rb
+++ b/test/processors/base_processor_test.rb
@@ -35,8 +35,4 @@ class BaseProcessorTest < Minitest::Test
     result = processor.call(Object.new, Feed.new).value!
     assert_equal(ENTITIES, result)
   end
-
-  def test_abstract_entities
-    assert_raises(NotImplementedError) { subject.call(Object.new, Feed.new) }
-  end
 end

--- a/test/support/normalizer_test_helper.rb
+++ b/test/support/normalizer_test_helper.rb
@@ -2,19 +2,19 @@ module NormalizerTestHelper
   SAMPLE_DATA_PATH = File.expand_path('../data', __dir__).freeze
 
   def subject
-    raise NotImplementedError
+    raise 'not implemented'
   end
 
   def processor
-    raise NotImplementedError
+    raise 'not implemented'
   end
 
   def sample_data_file
-    raise NotImplementedError
+    raise 'not implemented'
   end
 
   def sample_post_file
-    raise NotImplementedError
+    raise 'not implemented'
   end
 
   protected

--- a/test/support/processor_test_helpers.rb
+++ b/test/support/processor_test_helpers.rb
@@ -6,7 +6,7 @@ module ProcessorTestHelpers
   end
 
   def sample_data_file
-    raise NotImplementedError
+    raise 'not implemented'
   end
 
   def sample_data


### PR DESCRIPTION
Motivation: `NotImplementedError` is designated to indicate Ruby platform differences, not lacking abstract method implementation.