### PR TITLE
Improve Honeybadger errors notification

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -21,6 +21,7 @@ class APIController < ActionController::API
 
   def handle_error(exception, status, payload = nil)
     Rails.logger.error(exception)
+    Honeybadger.notify(exception)
     render(status: status, json: payload)
   end
 end

--- a/app/services/downloader.rb
+++ b/app/services/downloader.rb
@@ -4,13 +4,12 @@ class Downloader
   param :url
 
   def call
+    Honeybadger.context(url: url)
     io = StringIO.new
     io.set_encoding(Encoding::BINARY)
     io.write(response.body)
     io.rewind
     yield io, response.headers[:content_type]
-  rescue StandardError
-    raise "error downloading url: '#{url}'"
   end
 
   private


### PR DESCRIPTION
Updates:

- Do not wrap errors within `Downloader` class to preserve original error details.
- Add download URL to HB context.

References:

- https://app.honeybadger.io/projects/65419/faults/58605400