### PR TITLE
Remove unnecessary option from HttpLoader

### DIFF
--- a/app/loaders/http_loader.rb
+++ b/app/loaders/http_loader.rb
@@ -1,14 +1,7 @@
 class HttpLoader < BaseLoader
-  # TODO: Rename client to fetcher
-  option(
-    :client,
-    optional: true,
-    default: -> { ->(url) { RestClient.get(url).body } }
-  )
-
   protected
 
   def perform
-    client.call(feed.url)
+    RestClient.get(feed.url).body
   end
 end


### PR DESCRIPTION
Use WebMock instead of replacing HTTP client with a mock during testing.