### PR TITLE
Prevent Twitter media link duplication in the post body

### DIFF
--- a/app/normalizers/twitter_normalizer.rb
+++ b/app/normalizers/twitter_normalizer.rb
@@ -24,7 +24,7 @@ class TwitterNormalizer < BaseNormalizer
   end
 
   def text
-    [tweet_text, "!#{link}"].join(separator)
+    [tweet_text, "!#{link}"].compact.join(separator)
   rescue KeyError
     nil
   end
@@ -62,8 +62,17 @@ class TwitterNormalizer < BaseNormalizer
   end
 
   def tweet_text
+    return nil if media_link?
     content.fetch('text')
   rescue KeyError
+    full_text
+  end
+
+  def full_text
     content.fetch('full_text')
+  end
+
+  def media_link?
+    content.dig('media', 0, 'url') == full_text
   end
 end

--- a/app/normalizers/twitter_normalizer.rb
+++ b/app/normalizers/twitter_normalizer.rb
@@ -24,7 +24,7 @@ class TwitterNormalizer < BaseNormalizer
   end
 
   def text
-    [tweet_text, "!#{link}"].compact.join(separator)
+    [media_link? ? nil : tweet_text, "!#{link}"].compact.join(separator)
   rescue KeyError
     nil
   end
@@ -62,7 +62,6 @@ class TwitterNormalizer < BaseNormalizer
   end
 
   def tweet_text
-    return nil if media_link?
     content.fetch('text')
   rescue KeyError
     full_text
@@ -73,6 +72,6 @@ class TwitterNormalizer < BaseNormalizer
   end
 
   def media_link?
-    content.dig('media', 0, 'url') == full_text
+    content.dig('media', 0, 'url') == tweet_text
   end
 end

--- a/test/feeds/twitter_media_link_test.rb
+++ b/test/feeds/twitter_media_link_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class TwitterMediaLinkTest < Minitest::Test
+  include FeedTestHelper
+
+  def setup
+    super
+
+    # SEE: https://developer.twitter.com/en/docs/twitter-api/v1/tweets/timelines/api-reference/get-statuses-user_timeline
+    stub_request(:get, 'https://api.twitter.com/1.1/statuses/user_timeline.json?screen_name=alg_testament&tweet_mode=extended')
+      .to_return(
+        headers: { 'Content-Type' => 'application/json' },
+        body: file_fixture('feeds/twitter/user_timeline_media_link.json').read
+      )
+  end
+
+  def feed_config
+    {
+      loader: 'twitter',
+      processor: 'twitter',
+      normalizer: 'twitter',
+      options: {
+        twitter_user: 'alg_testament'
+      }
+    }
+  end
+
+  def expected_fixture_path
+    'feeds/twitter/entity_media_link.json'
+  end
+end

--- a/test/fixtures/files/feeds/twitter/entity_media_link.json
+++ b/test/fixtures/files/feeds/twitter/entity_media_link.json
@@ -1,0 +1,15 @@
+{
+  "uid": "850007368138018817",
+  "link": "https://twitter.com/twitterapi/status/850007368138018817",
+  "published_at": "2017-04-06 15:28:43 +0000",
+  "text": "!https://twitter.com/twitterapi/status/850007368138018817",
+  "attachments": [
+
+  ],
+  "comments": [
+
+  ],
+  "validation_errors": [
+
+  ]
+}

--- a/test/fixtures/files/feeds/twitter/user_timeline_media_link.json
+++ b/test/fixtures/files/feeds/twitter/user_timeline_media_link.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": 850007368138018817,
+    "created_at": "Thu Apr 06 15:28:43 +0000 2017",
+    "full_text": "https://t.co/V2vDjXDCH7",
+    "user": {
+      "screen_name": "twitterapi"
+    },
+    "media": [
+      {
+        "url": "https://t.co/V2vDjXDCH7"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Relevant for Twitter feeds with image-only tweets. In this case Feed entry text duplicates short media URL, which is redundant.

See #324.