### PR TITLE
Fix edge cases for the attachment downloader

### DIFF
--- a/app/processors/atom_processor.rb
+++ b/app/processors/atom_processor.rb
@@ -8,6 +8,6 @@ class AtomProcessor < BaseProcessor
   end
 
   def parse_content
-    RSS::Parser.parse(content, false).items
+    RSS::Parser.parse(content, false)&.items || []
   end
 end

--- a/app/services/downloader.rb
+++ b/app/services/downloader.rb
@@ -5,16 +5,28 @@ class Downloader
 
   def call
     Honeybadger.context(url: url)
-    io = StringIO.new
-    io.set_encoding(Encoding::BINARY)
-    io.write(response.body.to_s)
-    io.rewind
-    yield io, response.content_type.mime_type
+    response = get_url
+    return unless response&.status == 200
+    yield build_io_from(response), response.content_type.mime_type
   end
 
   private
 
-  def response
-    @response ||= HTTP.get(url)
+  def build_io_from(response)
+    StringIO.new.tap do |io|
+      io.set_encoding(Encoding::BINARY)
+      io.write(response.body.to_s)
+      io.rewind
+    end
+  end
+
+  MAX_HOPS = 3
+
+  private_constant :MAX_HOPS
+
+  def get_url
+    HTTP.follow(max_hops: MAX_HOPS).get(url)
+  rescue StandardError
+    nil
   end
 end

--- a/app/services/downloader.rb
+++ b/app/services/downloader.rb
@@ -5,7 +5,7 @@ class Downloader
 
   def call
     Honeybadger.context(url: url)
-    response = get_url
+    response = fetch_url
     return unless response&.status == 200
     yield build_io_from(response), response.content_type.mime_type
   end
@@ -24,7 +24,7 @@ class Downloader
 
   private_constant :MAX_HOPS
 
-  def get_url
+  def fetch_url
     HTTP.follow(max_hops: MAX_HOPS).get(url)
   rescue StandardError
     nil

--- a/spec/service/downloader_spec.rb
+++ b/spec/service/downloader_spec.rb
@@ -15,18 +15,12 @@ RSpec.describe Downloader do
 
   let(:binary_image_data) { file_fixture('1x1.png') }
   let(:non_ascii_url) { 'https://example.com/bürger.png' }
-
-  before do
-    [url, non_ascii_url].each do |image_url|
-      stub_request(:get, image_url)
-        .to_return(
-          headers: { 'Content-Type' => expected_content_type },
-          body: binary_image_data
-        )
-    end
-  end
+  let(:redirect_url) { 'https://example.com/1x1.png' }
+  let(:unparseable_urls) { [nil, '', '+&://WЯONG'] }
 
   it 'should download stuff' do
+    stub_request_with_image(url)
+
     service.call(url) do |io, content_type|
       expect(expected_io.read).to eq(io.read)
       expect(expected_content_type).to eq(content_type)
@@ -34,9 +28,49 @@ RSpec.describe Downloader do
   end
 
   it 'should accept non-ascii urls' do
+    stub_request_with_image(non_ascii_url)
+
+    service.call(non_ascii_url) do |io, content_type|
+      expect(expected_io.read).to eq(io.read)
+      expect(expected_content_type).to eq(content_type)
+    end
+  end
+
+  it 'should follow redirects' do
+    stub_request(:get, url).to_return(status: 301, headers: { 'Location' => redirect_url })
+    stub_request_with_image(redirect_url)
+
+    expect { |block| service.call(url, &block) }.to yield_control
+
     service.call(url) do |io, content_type|
       expect(expected_io.read).to eq(io.read)
       expect(expected_content_type).to eq(content_type)
     end
+  end
+
+  it 'should not yield on error' do
+    stub_request(:get, url).to_return(status: 404)
+    expect { |block| service.call(url, &block) }.to_not yield_control
+  end
+
+  it 'should not yield when too many redirects' do
+    stub_request(:get, url).to_return(status: 301, headers: { 'Location' => 'http://example.com/1' })
+    stub_request(:get, 'http://example.com/1').to_return(status: 301, headers: { 'Location' => 'https://example.com/2' })
+    stub_request(:get, 'https://example.com/2').to_return(status: 301, headers: { 'Location' => url })
+    expect { |block| service.call(url, &block) }.to_not yield_control
+  end
+
+  it 'should not yield when bad URL' do
+    unparseable_urls.each do |unparseable_url|
+      expect { |block| service.call(unparseable_url, &block) }.to_not yield_control
+    end
+  end
+
+  def stub_request_with_image(image_url)
+    stub_request(:get, image_url)
+      .to_return(
+        headers: { 'Content-Type' => expected_content_type },
+        body: binary_image_data
+      )
   end
 end


### PR DESCRIPTION
Updates:

- Follow redirects.
- Make sure HTTP response is a success, before processing downloaded image.

References:

- #387