### PR TITLE
Fix port definition for Puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.
 #
-# port ENV.fetch('PORT', 3000), '0.0.0.0'
+port ENV.fetch('PORT', 3000), '0.0.0.0'
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
"Port" option is required in Puma configuration on the production instance.