### PR TITLE
Ensure Twitter permalinks are HTTPS

### DIFF
--- a/app/services/nitter_permalink.rb
+++ b/app/services/nitter_permalink.rb
@@ -3,9 +3,10 @@ class NitterPermalink
 
   param :url
 
-  TWITTER_HOST = 'twitter.com'.freeze
-
   def call
-    URI.parse(url).tap { |uri| uri.host = TWITTER_HOST }.to_s
+    URI.parse(url).tap do |parsed|
+      parsed.host = 'twitter.com'
+      parsed.scheme = 'https'
+    end.to_s
   end
 end

--- a/spec/service/nitter_peralink_spec.rb
+++ b/spec/service/nitter_peralink_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe NitterPermalink do
+  subject(:service) { described_class }
+
+  it 'returns https links' do
+    result = service.call('http://example.com/nathanwpyle/status/1098710518058176512')
+    expect(result).to eq('https://twitter.com/nathanwpyle/status/1098710518058176512')
+  end
+
+  it 'tolerates anchors and GET params' do
+    result = service.call('https://example.com/nathanwpyle/status/1098710518058176512?s=20#banana')
+    expect(result).to eq('https://twitter.com/nathanwpyle/status/1098710518058176512?s=20#banana')
+  end
+end

--- a/spec/service/nitter_permalink_spec.rb
+++ b/spec/service/nitter_permalink_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe NitterPermalink do
   subject(:service) { described_class }


### PR DESCRIPTION
Some Nitter instances return use HTTP permalinks for Tweets. This cause occasional Tweets duplication, since Tweet permalinks are uids.

This patch replaces `http://` with `https://` in addition to replacing Nitter host with `twitter.com`.