### PR TITLE
Use more comfortable state transitions for `NitterInstance`

### DIFF
--- a/app/models/nitter_instance.rb
+++ b/app/models/nitter_instance.rb
@@ -18,14 +18,16 @@ class NitterInstance < ApplicationRecord
     event :error do
       after do
         update!(errored_at: Time.current, errors_count: errors_count.succ)
-        disable! if errors_count >= MAX_ERRORS
+        disable! if may_disable? && errors_count >= MAX_ERRORS
       end
 
       transitions from: %i[enabled errored], to: :errored
+      transitions from: :disabled, to: :disabled
+      transitions from: :removed, to: :removed
     end
 
     event :disable do
-      transitions from: :errored, to: :disabled
+      transitions from: %i[enabled errored], to: :disabled
     end
 
     event :enable do

--- a/spec/models/nitter_instance_spec.rb
+++ b/spec/models/nitter_instance_spec.rb
@@ -19,6 +19,18 @@ RSpec.describe NitterInstance do
     expect(nitter_instance.errors_count).to eq(2)
   end
 
+  it 'can register errors when disabled' do
+    nitter_instance.disable!
+    nitter_instance.error!
+    expect(nitter_instance.errors_count).to eq(1)
+  end
+
+  it 'can register errors when removed' do
+    nitter_instance.remove!
+    nitter_instance.error!
+    expect(nitter_instance.errors_count).to eq(1)
+  end
+
   it 'disables after max errors limit exceeded' do
     nitter_instance.update!(errors_count: NitterInstance::MAX_ERRORS.pred)
     nitter_instance.error!


### PR DESCRIPTION
Updates:

- Allow registering `NitterInstance` errors in any state to prevent race conditions.

References:

- https://app.honeybadger.io/projects/65419/faults/96754247