### PR TITLE
Follow HTTP redirects during feed URL load

### DIFF
--- a/app/loaders/http_loader.rb
+++ b/app/loaders/http_loader.rb
@@ -18,7 +18,11 @@ class HttpLoader < BaseLoader
     Honeybadger.context(http_response: response.as_json)
   end
 
+  MAX_HOPS = 3
+
+  private_constant :MAX_HOPS
+
   def response
-    @response ||= HTTP.get(feed.url)
+    @response ||= HTTP.follow(max_hops: MAX_HOPS).get(feed.url)
   end
 end

--- a/spec/loaders/http_loader_spec.rb
+++ b/spec/loaders/http_loader_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe HttpLoader do
   let(:feed) { build(:feed) }
   let(:content) { 'BANANA' }
   let(:arbitrary_error) { 'arbitrary error object' }
+  let(:redirect_url) { 'https://example.com/redirect' }
 
   it 'requires feed url to present' do
     feed.url = nil
@@ -30,5 +31,24 @@ RSpec.describe HttpLoader do
   it 'passes request execution errors' do
     stub_request(:get, feed.url).to_raise(arbitrary_error)
     expect { loader.call(feed) }.to raise_error(arbitrary_error)
+  end
+
+  it 'follows redirects' do
+    stub_get_request_with_redirects(feed.url, hops: 2)
+    expect(loader.call(feed)).to eq(content)
+  end
+
+  it 'raises if too many redirects' do
+    stub_get_request_with_redirects(feed.url, hops: 4)
+    expect { loader.call(feed) }.to raise_error(HTTP::Redirector::TooManyRedirectsError)
+  end
+
+  def stub_get_request_with_redirects(url, hops:)
+    hops.times do |hop|
+      redirect_from = hop.zero? ? url : "#{redirect_url}#{hop}"
+      stub_request(:get, redirect_from).to_return(status: 301, headers: { 'Location' => "#{redirect_url}#{hop.succ}" })
+    end
+
+    stub_request(:get, "#{redirect_url}#{hops}").to_return(body: content)
   end
 end


### PR DESCRIPTION
Medium feed URLs respond with 301.