### PR TITLE
Keep undefined values in the end of the sorted sequence

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -71,7 +71,7 @@ class Feed < ApplicationRecord
     end
   end
 
-  scope :ordered_by, ->(attribute, direction) { order(attribute => direction).order(Arel.sql("last_post_created_at IS NULL, last_post_created_at DESC")) }
+  scope :ordered_by, ->(attribute, direction) { order(sanitize_sql_for_order("#{attribute} #{direction} NULLS LAST")) }
 
   scope :stale, lambda {
     where(refresh_interval: 0)

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -26,6 +26,43 @@ RSpec.describe Feed do
     expect(described_class.new.import_limit).to be_nil
   end
 
+  describe "ordered_by" do
+    let(:sample_timestamps) do
+      [
+        DateTime.parse("2023-06-16 02:00:00 +0000"),
+        DateTime.parse("2023-06-16 01:00:00 +0000"),
+        DateTime.parse("2023-06-16 00:00:00 +0000")
+      ]
+    end
+
+    let(:feed_with_no_refreshed_at) { create(:feed, refreshed_at: nil) }
+
+    before do
+      sample_timestamps.each { |timestamp| create(:feed, refreshed_at: timestamp) }
+    end
+
+    it "orders records" do
+      timestamps = ordered_by_refreshed_at(:desc).pluck(:refreshed_at)
+      expect(timestamps).to eq(sample_timestamps.sort.reverse)
+    end
+
+    it "keeps null last during desc ordering" do
+      feed_with_no_refreshed_at
+      last_feed_id = ordered_by_refreshed_at(:desc).pluck(:id).last
+      expect(last_feed_id).to eq(feed_with_no_refreshed_at.id)
+    end
+
+    it "keeps null last during asc ordering" do
+      feed_with_no_refreshed_at
+      last_feed_id = ordered_by_refreshed_at(:desc).pluck(:id).last
+      expect(last_feed_id).to eq(feed_with_no_refreshed_at.id)
+    end
+
+    def ordered_by_refreshed_at(direction)
+      described_class.ordered_by(:refreshed_at, direction)
+    end
+  end
+
   describe "stale" do
     it "inits treat new feed as stale" do
       expect(described_class.new).to be_stale

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Feed do
 
     it "keeps null last during asc ordering" do
       feed_with_no_refreshed_at
-      last_feed_id = ordered_by_refreshed_at(:desc).pluck(:id).last
+      last_feed_id = ordered_by_refreshed_at(:asc).pluck(:id).last
       expect(last_feed_id).to eq(feed_with_no_refreshed_at.id)
     end
 


### PR DESCRIPTION
So empty cells won't pop to the top if the feeds list.