### PR TITLE
Improve presentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "addressable", "~> 2.8"
 gem "amazing_print"
 gem "bootsnap", ">= 1.4.2", require: false
 gem "callee", "~> 0.3"
+gem "dotiw", "~> 5.3"
 gem "dry-initializer", "~> 3.0", ">= 3.0.4"
 gem "dry-types", "~> 1.5", ">= 1.5.1"
 gem "dry-validation", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotiw (5.3.3)
+      activesupport
+      i18n
     dry-configurable (0.16.1)
       dry-core (~> 0.6)
       zeitwerk (~> 2.6)
@@ -388,6 +391,7 @@ DEPENDENCIES
   bundler-audit
   callee (~> 0.3)
   database_cleaner-active_record
+  dotiw (~> 5.3)
   dry-initializer (~> 3.0, >= 3.0.4)
   dry-types (~> 1.5, >= 1.5.1)
   dry-validation (~> 1.7)
@@ -425,4 +429,4 @@ DEPENDENCIES
   webmock (~> 3.11)
 
 BUNDLED WITH
-   2.4.13
+   2.3.24

--- a/app/helpers/feeds_table_helper.rb
+++ b/app/helpers/feeds_table_helper.rb
@@ -50,11 +50,11 @@ module FeedsTableHelper
       order: "desc"
     },
     "refreshed_at" => {
-      caption: "Refreshed at",
+      caption: "Refreshed",
       order: "desc"
     },
     "last_post_created_at" => {
-      caption: "Daily imports",
+      caption: "Imports",
       order: "desc",
       classes: "feeds-table__sparkline-column"
     }

--- a/app/helpers/feeds_table_helper.rb
+++ b/app/helpers/feeds_table_helper.rb
@@ -56,7 +56,7 @@ module FeedsTableHelper
     "last_post_created_at" => {
       caption: "Daily imports",
       order: "desc",
-      classes: "sparkline-column"
+      classes: "feeds-table__sparkline-column"
     }
   }.freeze
 

--- a/app/helpers/formatting_helper.rb
+++ b/app/helpers/formatting_helper.rb
@@ -3,6 +3,10 @@ module FormattingHelper
     time ? "#{distance_of_time_in_words_to_now(time).gsub("about ", "")} ago" : ""
   end
 
+  def compact_ago(time)
+    distance_of_time_in_words_to_now(time, compact: true, highest_measure_only: true)
+  end
+
   def format_feed_state(feed)
     state = feed.state
 

--- a/app/helpers/sparkline_helper.rb
+++ b/app/helpers/sparkline_helper.rb
@@ -2,7 +2,12 @@ module SparklineHelper
   def generate_feed_sparkline(feed)
     tag.span(class: "sparkline") do
       feed.sparkline_points.each do |point|
-        concat(tag.span(title: sparkline_tooltip(point["date"], point["value"].to_i)) { point["sparky"].presence || "&nbsp;".html_safe })
+        concat(
+          tag.span(
+            title: sparkline_tooltip(point["date"], point["value"].to_i),
+            class: "sparkline__item"
+          ) { point["sparky"].presence || "&nbsp;".html_safe }
+        )
       end
     end
   end

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -21,7 +21,7 @@
     </div>
 </div>
 
-<table class="table table-bordered my-4">
+<table class="table table-bordered my-4 feeds-table">
   <%= feeds_table_header(order_by: order_by, order: order) -%>
   <tbody>
     <%- feeds.each do |feed| -%>

--- a/app/views/feeds/index.html.erb
+++ b/app/views/feeds/index.html.erb
@@ -32,7 +32,7 @@
         <td>
           <%- if feed.refreshed_at -%>
             <%= tag.time datetime: feed.refreshed_at.rfc3339 do -%>
-              <%= ago(feed.refreshed_at) -%>
+              <%= compact_ago(feed.refreshed_at) -%>
             <%- end -%>
           <%- end -%>
         </td>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,8 +21,10 @@
         border-bottom-color: hotpink;
       }
       .feeds-table__sparkline-column {
-        white-space: nowrap;
         width: 1%;
+      }
+      .feeds-table td {
+        white-space: nowrap;
       }
     </style>
     <%= render(partial: 'partials/google_analytics') unless Rails.env.production? -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,13 +8,19 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/hint.css/1.2.1/hint.min.css" integrity="sha512-VgCRZpenEX+OZNOBG+yA2TWvWmIwe+gjSe9HmodkkOusP/pCF3zZCvg1RJc4eQ+pEhw9X1fU7ss9HmgzxBMOfQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <title><%= content_for?(:title) ? yield(:title) : 'Feeder' -%></title>
     <link rel="icon" href="data:,">
+    <%# TODO: Extract element styles to proper location %>
     <style>
-      .sparkline {
-        font-family: monospace;
+      .sparkline__item {
         color: lightgray;
         border-bottom: 1px solid lightgray;
+        font-family: monospace;
+        cursor: default;
       }
-      .sparkline-column {
+      .sparkline__item:hover {
+        color: hotpink;
+        border-bottom-color: hotpink;
+      }
+      .feeds-table__sparkline-column {
         white-space: nowrap;
         width: 1%;
       }

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Feed do
     let(:feed_with_no_refreshed_at) { create(:feed, refreshed_at: nil) }
 
     before do
+      described_class.delete_all
       sample_timestamps.each { |timestamp| create(:feed, refreshed_at: timestamp) }
     end
 

--- a/spec/service/feed_updater_spec.rb
+++ b/spec/service/feed_updater_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe FeedUpdater do
     }
   end
 
+  before { Feed.delete_all }
+
   it "updates configurable attributes" do
     expect { call_service(pristine_feed.name, true, configuration) }
       .to(change { attrs(pristine_feed) }.from(feed_before_update).to(feed_after_update))


### PR DESCRIPTION
- Use compact format for timestamps.
- Turn off word wrapping in the feeds table.