### PR TITLE
Simplify `NormalizedEntity` implementation

### DIFF
--- a/app/models/normalized_entity.rb
+++ b/app/models/normalized_entity.rb
@@ -1,6 +1,8 @@
+# :reek:TooManyInstanceVariables
 class NormalizedEntity
   attr_reader :feed_id, :uid, :link, :published_at, :text, :attachments, :comments, :validation_errors
 
+  # :reek:LongParameterList
   def initialize(
     feed_id: nil,
     uid: nil,
@@ -14,7 +16,7 @@ class NormalizedEntity
     @feed_id = feed_id
     @uid = uid
     @link = link
-    @published_at = published_at
+    @published_at = published_at&.to_datetime
     @text = text
     @attachments = attachments
     @comments = comments
@@ -38,7 +40,7 @@ class NormalizedEntity
       feed_id: feed_id,
       uid: uid,
       link: link,
-      published_at: published_at,
+      published_at: serialized_published_at,
       text: text,
       attachments: attachments,
       comments: comments,
@@ -47,6 +49,10 @@ class NormalizedEntity
   end
 
   private
+
+  def serialized_published_at
+    published_at&.to_time.to_s
+  end
 
   def existing_post
     Post.find_by(feed_id: feed_id, uid: uid)

--- a/app/models/normalized_entity.rb
+++ b/app/models/normalized_entity.rb
@@ -38,22 +38,18 @@ class NormalizedEntity
 
   def as_json
     {
-      feed_id: feed_id,
-      uid: uid,
-      link: link,
-      published_at: serialized_published_at,
-      text: text,
-      attachments: attachments,
-      comments: comments,
-      validation_errors: validation_errors
-    }.as_json
+      "feed_id" => feed_id,
+      "uid" => uid,
+      "link" => link,
+      "published_at" => published_at&.to_time.to_s,
+      "text" => text,
+      "attachments" => attachments,
+      "comments" => comments,
+      "validation_errors" => validation_errors
+    }
   end
 
   private
-
-  def serialized_published_at
-    published_at&.to_time.to_s
-  end
 
   def existing_post
     Post.find_by(feed_id: feed_id, uid: uid)

--- a/app/models/normalized_entity.rb
+++ b/app/models/normalized_entity.rb
@@ -1,17 +1,28 @@
 class NormalizedEntity
-  extend Dry::Initializer
+  attr_reader :feed_id, :uid, :link, :published_at, :text, :attachments, :comments, :validation_errors
 
-  option :feed_id, optional: true
-  option :uid, optional: true
-  option :link, optional: true
-  option :published_at, optional: true
-  option :text, optional: true
-  option :attachments, optional: true
-  option :comments, optional: true
-  option :validation_errors, optional: true, default: -> { [] }
+  def initialize(
+    feed_id: nil,
+    uid: nil,
+    link: "",
+    published_at: nil,
+    text: "",
+    attachments: [],
+    comments: [],
+    validation_errors: []
+  )
+    @feed_id = feed_id
+    @uid = uid
+    @link = link
+    @published_at = published_at
+    @text = text
+    @attachments = attachments
+    @comments = comments
+    @validation_errors = validation_errors
+  end
 
   def ==(other)
-    comparable_attributes(self) == comparable_attributes(other)
+    as_json == other.as_json
   end
 
   def stale?
@@ -23,7 +34,16 @@ class NormalizedEntity
   end
 
   def as_json
-    instance_values
+    {
+      feed_id: feed_id,
+      uid: uid,
+      link: link,
+      published_at: published_at,
+      text: text,
+      attachments: attachments,
+      comments: comments,
+      validation_errors: validation_errors
+    }.as_json
   end
 
   private
@@ -55,22 +75,5 @@ class NormalizedEntity
 
   def feed
     @feed ||= Feed.find(feed_id)
-  end
-
-  COMPARABLE_ATTRIBUTES = %w[
-    feed_id
-    uid
-    link
-    published_at
-    text
-    attachments
-    comments
-    validation_errors
-  ].freeze
-
-  private_constant :COMPARABLE_ATTRIBUTES
-
-  def comparable_attributes(subject)
-    subject.instance_values.slice(*COMPARABLE_ATTRIBUTES)
   end
 end

--- a/app/services/process_feed.rb
+++ b/app/services/process_feed.rb
@@ -16,7 +16,7 @@ class ProcessFeed
 
   def generate_new_posts
     feed.touch(:refreshed_at)
-    normalized_entities.each { |normalized_entity| push(normalized_entity) }
+    normalized_entities.reverse.each { |normalized_entity| push(normalized_entity) }
     feed.update(errors_count: 0)
     feed.update_sparkline
   rescue StandardError => e

--- a/app/services/process_feed.rb
+++ b/app/services/process_feed.rb
@@ -16,7 +16,7 @@ class ProcessFeed
 
   def generate_new_posts
     feed.touch(:refreshed_at)
-    normalized_entities.reverse.each { |normalized_entity| push(normalized_entity) }
+    normalized_entities.reverse_each { |normalized_entity| push(normalized_entity) }
     feed.update(errors_count: 0)
     feed.update_sparkline
   rescue StandardError => e

--- a/spec/fixtures/files/feeds/commitstrip/entity.json
+++ b/spec/fixtures/files/feeds/commitstrip/entity.json
@@ -2,7 +2,7 @@
   "feed_id": null,
   "uid": "https://www.commitstrip.com/2017/09/19/the-whole-teams-working-on-it/",
   "link": "https://www.commitstrip.com/2017/09/19/the-whole-teams-working-on-it/",
-  "published_at": "2017-09-19 16:42:52 UTC",
+  "published_at": "2017-09-19 16:42:52 +0000",
   "text": "The whole team’s working on it - https://www.commitstrip.com/2017/09/19/the-whole-teams-working-on-it/",
   "attachments": ["https://www.commitstrip.com/wp-content/uploads/2017/09/Strip-La-super-équipe-de-maintenance-650-finalenglish.jpg"],
   "comments": [],

--- a/spec/fixtures/files/feeds/hackernews/expected_normalizer_result.json
+++ b/spec/fixtures/files/feeds/hackernews/expected_normalizer_result.json
@@ -3,7 +3,7 @@
     "feed_id": 182,
     "uid": 100005,
     "link": "https://news.ycombinator.com/item?id=100005",
-    "published_at": "2023-06-16T03:44:10.000Z",
+    "published_at": "2023-06-16 03:44:10 +0000",
     "text": "Sample title - https://example.com/",
     "attachments":
     [],
@@ -18,7 +18,7 @@
     "feed_id": 182,
     "uid": 100003,
     "link": "https://news.ycombinator.com/item?id=100003",
-    "published_at": "2023-06-16T03:43:50.000Z",
+    "published_at": "2023-06-16 03:43:50 +0000",
     "text": "Sample title - https://example.com/",
     "attachments":
     [],

--- a/spec/fixtures/files/feeds/kotaku/normalized.json
+++ b/spec/fixtures/files/feeds/kotaku/normalized.json
@@ -3,7 +3,7 @@
     "feed_id": 1753,
     "uid": "https://kotaku.com/vinland-saga-season-2-thorfinn-netflix-crunchyroll-mapp-1850549053",
     "link": "https://kotaku.com/vinland-saga-season-2-thorfinn-netflix-crunchyroll-mapp-1850549053",
-    "published_at": "2023-06-16 21:00:00 UTC",
+    "published_at": "2023-06-16 21:00:00 +0000",
     "text": "Vinland Saga Second Season’s Lack Of Action Is A Good Thing by Isaiah Colbert - https://kotaku.com/vinland-saga-season-2-thorfinn-netflix-crunchyroll-mapp-1850549053",
     "attachments":
     [
@@ -20,7 +20,7 @@
     "feed_id": 1753,
     "uid": "https://kotaku.com/nintendo-switch-eshop-hidden-gems-sale-pride-queer-1850549209",
     "link": "https://kotaku.com/nintendo-switch-eshop-hidden-gems-sale-pride-queer-1850549209",
-    "published_at": "2023-06-16 21:15:00 UTC",
+    "published_at": "2023-06-16 21:15:00 +0000",
     "text": "Someone At Nintendo Snuck Pride Month Into The Switch's eShop by Levi Winslow - https://kotaku.com/nintendo-switch-eshop-hidden-gems-sale-pride-queer-1850549209",
     "attachments":
     [

--- a/spec/fixtures/files/feeds/kotaku_daily/normalized.json
+++ b/spec/fixtures/files/feeds/kotaku_daily/normalized.json
@@ -3,7 +3,7 @@
     "feed_id": 3092,
     "uid": "2023-06-16T00:00:00+00:00",
     "link": "https://kotaku.com/latest?startTime=1686959999999",
-    "published_at": "2023-06-16T00:00:00.000+00:00",
+    "published_at": "2023-06-16 00:00:00 +0000",
     "text": "Kotaku top 5 posts for 16 Jun 2023 - https://kotaku.com/latest?startTime=1686959999999",
     "attachments":
     [

--- a/spec/fixtures/files/feeds/nextbigfuture/entity.json
+++ b/spec/fixtures/files/feeds/nextbigfuture/entity.json
@@ -3,7 +3,7 @@
   "comments": ["There have been many books written about\\n\\nthe rise of China"],
   "feed_id": 1294,
   "link": "https://www.nextbigfuture.com/2018/11/rise-of-china-and-strictly-business-competition-in-the-world.html",
-  "published_at": "2018-11-27 09:19:49.000000000 +0000",
+  "published_at": "2018-11-27 09:19:49 +0000",
   "text": "Rise of China and Strictly Business Competition in the World - https://www.nextbigfuture.com/2018/11/rise-of-china-and-strictly-business-competition-in-the-world.html",
   "uid": "https://www.nextbigfuture.com/2018/11/rise-of-china-and-strictly-business-competition-in-the-world.html",
   "validation_errors": []

--- a/spec/models/normalized_entity_spec.rb
+++ b/spec/models/normalized_entity_spec.rb
@@ -26,4 +26,40 @@ RSpec.describe NormalizedEntity do
       model.new(feed_id: feed.id, **attributes)
     end
   end
+
+  describe "#==" do
+    it { expect(model.new).to eq(model.new) }
+  end
+
+  describe "#as_json" do
+    let(:expected) do
+      {
+        "feed_id" => "FEED_ID",
+        "uid" => "UID",
+        "link" => "LINK",
+        "published_at" => published_at.to_s,
+        "text" => "TEST",
+        "attachments" => ["https://example.com/image.jpg"],
+        "comments" => ["I'm a comment"],
+        "validation_errors" => []
+      }
+    end
+
+    let(:instance) do
+      model.new(
+        feed_id: "FEED_ID",
+        uid: "UID",
+        link: "LINK",
+        published_at: published_at.to_s,
+        text: "TEST",
+        attachments: ["https://example.com/image.jpg"],
+        comments: ["I'm a comment"],
+        validation_errors: []
+      )
+    end
+
+    let(:published_at) { Time.current }
+
+    it { expect(instance.as_json).to eq(expected) }
+  end
 end

--- a/spec/models/normalized_entity_spec.rb
+++ b/spec/models/normalized_entity_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe NormalizedEntity do
   end
 
   describe "#==" do
-    it { expect(model.new).to eq(model.new) }
+    let(:instance) { model.new }
+
+    it { expect(instance).to eq(instance.dup) }
   end
 
   describe "#as_json" do
@@ -37,7 +39,7 @@ RSpec.describe NormalizedEntity do
         "feed_id" => "FEED_ID",
         "uid" => "UID",
         "link" => "LINK",
-        "published_at" => published_at.to_s,
+        "published_at" => published_at.to_time.to_s,
         "text" => "TEST",
         "attachments" => ["https://example.com/image.jpg"],
         "comments" => ["I'm a comment"],
@@ -50,7 +52,7 @@ RSpec.describe NormalizedEntity do
         feed_id: "FEED_ID",
         uid: "UID",
         link: "LINK",
-        published_at: published_at.to_s,
+        published_at: published_at,
         text: "TEST",
         attachments: ["https://example.com/image.jpg"],
         comments: ["I'm a comment"],

--- a/spec/normalizers/commitstrip_normalizer_spec.rb
+++ b/spec/normalizers/commitstrip_normalizer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe CommitstripNormalizer do
   let(:expected_entity) do
     JSON.parse(file_fixture("feeds/commitstrip/entity.json").read).tap do |data|
       data["feed_id"] = feed.id
-      data["published_at"] = Time.zone.parse(data["published_at"])
     end
   end
 

--- a/spec/normalizers/hackernews_normalizer_spec.rb
+++ b/spec/normalizers/hackernews_normalizer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe HackernewsNormalizer do
 
   let(:expected) do
     JSON.parse(file_fixture("feeds/hackernews/expected_normalizer_result.json").read).map do |data|
-      data.merge("feed_id" => feed.id, "published_at" => DateTime.parse(data["published_at"]))
+      data.merge("feed_id" => feed.id)
     end
   end
 

--- a/spec/normalizers/kotaku_daily_normalizer_spec.rb
+++ b/spec/normalizers/kotaku_daily_normalizer_spec.rb
@@ -10,10 +10,7 @@ RSpec.describe KotakuDailyNormalizer do
 
   let(:expected) do
     JSON.parse(file_fixture("feeds/kotaku_daily/normalized.json").read).map do |data|
-      data.merge(
-        "feed_id" => feed.id,
-        "published_at" => DateTime.parse(data["published_at"])
-      )
+      data.merge("feed_id" => feed.id)
     end
   end
 

--- a/spec/normalizers/kotaku_normalizer_spec.rb
+++ b/spec/normalizers/kotaku_normalizer_spec.rb
@@ -10,10 +10,7 @@ RSpec.describe KotakuNormalizer do
 
   let(:expected) do
     JSON.parse(file_fixture("feeds/kotaku/normalized.json").read).map do |data|
-      data.merge(
-        "feed_id" => feed.id,
-        "published_at" => DateTime.parse(data["published_at"])
-      )
+      data.merge("feed_id" => feed.id)
     end
   end
 

--- a/spec/normalizers/nextbigfuture_normalizer_spec.rb
+++ b/spec/normalizers/nextbigfuture_normalizer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe NextbigfutureNormalizer do
   let(:expected_entity) do
     JSON.parse(file_fixture("feeds/nextbigfuture/entity.json").read).tap do |data|
       data["feed_id"] = feed.id
-      data["published_at"] = Time.zone.parse(data["published_at"])
     end
   end
 

--- a/spec/normalizers/nitter_normalizer_spec.rb
+++ b/spec/normalizers/nitter_normalizer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe NitterNormalizer do
       "feed_id" => nil,
       "uid" => "https://nitter.net/extrafabulous/status/1664634629456887813#m",
       "link" => "https://twitter.com/extrafabulous/status/1664634629456887813#m",
-      "published_at" => Time.parse("2023-06-02 14:06:37 UTC"),
+      "published_at" => "2023-06-02 14:06:37 +0000",
       "text" => "Image - !https://twitter.com/extrafabulous/status/1664634629456887813#m",
       "attachments" => ["https://nitter.net/pic/media%2FFxn4X5JWYAcPDCS.jpg"],
       "comments" => [],

--- a/test/normalizers/infiniteimmortalbens_normalizer_test.rb
+++ b/test/normalizers/infiniteimmortalbens_normalizer_test.rb
@@ -35,7 +35,7 @@ class InfiniteimmortalbensNormalizerTest < Minitest::Test
 
   def test_published_at
     normalized.each do |entity|
-      assert(entity.published_at.is_a?(Time))
+      assert(entity.published_at.is_a?(DateTime))
     end
   end
 


### PR DESCRIPTION
- Implement `NormalizedEntity` model as PORO.
- Unify `published_at` timestamp to `DateTime`.
- Do not preprocess timestamp during tests setup.