### PR TITLE
Prevent HN duplicates

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -80,6 +80,7 @@ class Feed < ApplicationRecord
       .or(where("age(now(), refreshed_at) > make_interval(secs => refresh_interval)"))
   }
 
+  # @return [true, false] true when the feed needs a refresh
   def stale?
     refresh_interval.zero? || !refreshed_at || too_long_since_last_refresh?
   end

--- a/app/models/normalized_entity.rb
+++ b/app/models/normalized_entity.rb
@@ -14,6 +14,7 @@ class NormalizedEntity
     comparable_attributes(self) == comparable_attributes(other)
   end
 
+  # @return [true, false] true if the entity is older than feed import threshold ("after")
   def stale?
     feed_after.present? && (published_at_or_default < feed_after)
   end

--- a/app/processors/hackernews_processor.rb
+++ b/app/processors/hackernews_processor.rb
@@ -4,7 +4,7 @@ class HackernewsProcessor < BaseProcessor
   protected
 
   def entities
-    above_score_threshold.map { build_entity(_1.fetch("id"), _1) }
+    above_score_threshold.map { build_entity(_1.fetch("id").to_s, _1) }
   end
 
   def above_score_threshold

--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -120,7 +120,6 @@
   import_limit: 2
 
 - name: "best-of-hacker-news"
-  enabled: false
   loader: "hackernews"
   processor: "hackernews"
   normalizer: "hackernews"

--- a/spec/fixtures/files/feeds/hackernews/expected_normalizer_result.json
+++ b/spec/fixtures/files/feeds/hackernews/expected_normalizer_result.json
@@ -1,7 +1,7 @@
 [
   {
     "feed_id": 182,
-    "uid": 100005,
+    "uid": "100005",
     "link": "https://news.ycombinator.com/item?id=100005",
     "published_at": "2023-06-16T03:44:10.000Z",
     "text": "Sample title - https://example.com/",
@@ -16,7 +16,7 @@
   },
   {
     "feed_id": 182,
-    "uid": 100003,
+    "uid": "100003",
     "link": "https://news.ycombinator.com/item?id=100003",
     "published_at": "2023-06-16T03:43:50.000Z",
     "text": "Sample title - https://example.com/",

--- a/spec/normalizers/hackernews_normalizer_spec.rb
+++ b/spec/normalizers/hackernews_normalizer_spec.rb
@@ -4,7 +4,7 @@ require "support/shared_hackernews_stubs"
 RSpec.describe HackernewsNormalizer do
   subject(:normalizer) { described_class }
 
-  let(:feed) { create(:feed, loader: "hackernews", processor: "hackernews", normalizer: "hackernews", import_limit: 2) }
+  let(:feed) { create(:feed, :hackernews) }
 
   let(:result) { entities.map { |entity| normalizer.call(entity) }.as_json }
   let(:entities) { HackernewsProcessor.call(content: content, feed: feed) }

--- a/spec/processors/hackernews_processor_spec.rb
+++ b/spec/processors/hackernews_processor_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe HackernewsProcessor do
   subject(:processor) { described_class }
 
   let(:entities) { processor.call(content: content, feed: feed) }
-  let(:feed) { create(:feed, loader: "hackernews", processor: "hackernews", import_limit: 2) }
+  let(:feed) { create(:feed, :hackernews) }
   let(:content) { HackernewsLoader.call(feed) }
   let(:expected_content) { JSON.parse(file_fixture("feeds/hackernews/expected_processor_result.json").read) }
 

--- a/spec/processors/hackernews_processor_spec.rb
+++ b/spec/processors/hackernews_processor_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe HackernewsProcessor do
   end
 
   it "filters most recent entities" do
-    expect(entities.map(&:uid)).to eq([100005, 100003])
+    expect(entities.map(&:uid)).to eq(%w[100005 100003])
   end
 
   it "returns expected content" do

--- a/test/factories/feed_factory.rb
+++ b/test/factories/feed_factory.rb
@@ -82,5 +82,12 @@ FactoryBot.define do
       refresh_interval { 86400 }
       import_limit { 2 }
     end
+
+    trait :hackernews do
+      loader { "hackernews" }
+      processor { "hackernews" }
+      normalizer { "hackernews" }
+      import_limit { 2 }
+    end
   end
 end


### PR DESCRIPTION
Why HN duplicates 🤔

```ruby
feed = Feed.find(15)
feed.import_limit = 100
content = feed.loader_class.new(feed).call
entities = feed.processor_class.new(content: content, feed: feed).call

entities.map { _1.content.slice("id", "title")}
Post.where(uid: entities.map { _1.content["id"] }).count
# 28

nes = entities.map { feed.normalizer_class.new(_1).call }

existing_uids = Post.where(uid: entities.map { _1.content["id"] }).pluck(:uid)
```

Dupes were caused by the implicit Integer → String conversion.
