### PR TITLE
Fix Honeybadger breadcrumbs for HTTP request

### DIFF
--- a/app/support/request_tracking.rb
+++ b/app/support/request_tracking.rb
@@ -6,7 +6,7 @@ class RequestTracking < HTTP::Feature
   HTTP::Options.register_feature(:request_tracking, self)
 
   def wrap_request(request)
-    breadcrumb("HTTP Request", request: request_data(request))
+    breadcrumb("HTTP Request", request: flatten_request_data(request))
     request
   end
 
@@ -15,9 +15,8 @@ class RequestTracking < HTTP::Feature
     response
   end
 
-  # TODO: Figure out why HTTP ignores this method
   def on_error(request, error)
-    breadcrumb("HTTP Request Error", request: request_data(request), error: error.as_json)
+    breadcrumb("HTTP Request Error", request: flatten_request_data(request), error: error.inspect)
   end
 
   private
@@ -27,11 +26,11 @@ class RequestTracking < HTTP::Feature
   end
 
   # SEE: https://github.com/httprb/http/blob/main/lib/http/request.rb
-  def request_data(request)
+  def flatten_request_data(request)
     {
       verb: request.verb,
       uri: request.uri.to_s,
-      headers: request.headers.to_h
+      headers: request.headers.to_h.to_json
     }.as_json
   end
 
@@ -39,9 +38,9 @@ class RequestTracking < HTTP::Feature
   def response_data(response)
     {
       status: response.status,
-      headers: response.headers.to_h,
+      headers: response.headers.to_h.to_json,
       version: response.version,
-      proxy_headers: response.proxy_headers
+      proxy_headers: response.proxy_headers.to_json
     }.as_json
   end
 end

--- a/spec/support/request_tracking_spec.rb
+++ b/spec/support/request_tracking_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RequestTracking do
             request: {
               "verb" => "get",
               "uri" => uri,
-              "headers" => {"Content-Type": "application/json", "Host": "example.com", "User-Agent": "http.rb/5.1.1"}.to_json
+              "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
             }
           }
         }
@@ -56,7 +56,7 @@ RSpec.describe RequestTracking do
           metadata: {
             response: {
               "status" => 200,
-              "headers" => {"Content-Type": "application/json", "Host": "example.com", "User-Agent": "http.rb/5.1.1"}.to_json,
+              "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json,
               "proxy_headers" => [].to_json,
               "version" => "1.1"
             }
@@ -82,7 +82,7 @@ RSpec.describe RequestTracking do
             request: {
               "verb" => "get",
               "uri" => uri,
-              "headers" => {"Content-Type": "application/json", "Host": "example.com", "User-Agent": "http.rb/5.1.1"}.to_json
+              "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
             }
           }
         }

--- a/spec/support/request_tracking_spec.rb
+++ b/spec/support/request_tracking_spec.rb
@@ -5,61 +5,93 @@ RSpec.describe RequestTracking do
 
   let(:uri) { "https://example.com/" }
 
-  let(:expected_request_breadcrumb) do
-    [
-      "HTTP Request",
-      {
-        category: "request",
-        metadata: {
-          request: {
-            "verb" => "get",
-            "uri" => uri,
-            "headers" => {
-              "Connection" => "close",
-              "Host" => "example.com",
-              "User-Agent" => "http.rb/5.1.1"
+  let(:request) do
+    HTTP::Request.new(
+      verb: "GET",
+      uri: uri,
+      headers: {"Content-Type" => "application/json"},
+      version: "1.1"
+    )
+  end
+
+  let(:response) do
+    HTTP::Response.new(
+      connection: nil,
+      request: request,
+      status: 200,
+      headers: request.headers,
+      version: "1.1"
+    )
+  end
+
+  describe "request processing" do
+    let(:expected_request_breadcrumb) do
+      [
+        "HTTP Request",
+        {
+          category: "request",
+          metadata: {
+            request: {
+              "verb" => "get",
+              "uri" => uri,
+              "headers" => {"Content-Type": "application/json", "Host": "example.com", "User-Agent": "http.rb/5.1.1"}.to_json
             }
           }
         }
-      }
-    ]
+      ]
+    end
+
+    it "creates breadcrumb on request" do
+      expect(Honeybadger).to receive(:add_breadcrumb).with(*expected_request_breadcrumb)
+      expect(feature.new.wrap_request(request)).to eq(request)
+    end
   end
 
-  let(:expected_response_breadcrumb) do
-    [
-      "HTTP Response",
-      {
-        category: "request",
-        metadata: {
-          response: {
-            "status" => 200,
-            "headers" => {"Content-Type" => "application/json"},
-            "proxy_headers" => [],
-            "version" => "1.1"
+  describe "Response processing" do
+    let(:expected_response_breadcrumb) do
+      [
+        "HTTP Response",
+        {
+          category: "request",
+          metadata: {
+            response: {
+              "status" => 200,
+              "headers" => {"Content-Type": "application/json", "Host": "example.com", "User-Agent": "http.rb/5.1.1"}.to_json,
+              "proxy_headers" => [].to_json,
+              "version" => "1.1"
+            }
           }
         }
-      }
-    ]
+      ]
+    end
+
+    it "creates breadcrumb on response" do
+      expect(Honeybadger).to receive(:add_breadcrumb).with(*expected_response_breadcrumb)
+      expect(feature.new.wrap_response(response)).to eq(response)
+    end
   end
 
-  it "creates breadcrumbs" do
-    stub_request(:get, uri)
-      .to_return(
-        status: 200,
-        body: "{}",
-        headers: {"Content-Type" => "application/json"}
-      )
+  describe "errors processing" do
+    let(:expected_error_breadcrumb) do
+      [
+        "HTTP Request Error",
+        {
+          category: "request",
+          metadata: {
+            error: "#<StandardError: sample error>",
+            request: {
+              "verb" => "get",
+              "uri" => uri,
+              "headers" => {"Content-Type": "application/json", "Host": "example.com", "User-Agent": "http.rb/5.1.1"}.to_json
+            }
+          }
+        }
+      ]
+    end
 
-    expect(Honeybadger).to receive(:add_breadcrumb).with(*expected_request_breadcrumb)
-    expect(Honeybadger).to receive(:add_breadcrumb).with(*expected_response_breadcrumb)
-    HTTP.use(:request_tracking).get(uri)
+    it "handle errors" do
+      expect(Honeybadger).to receive(:add_breadcrumb).with(*expected_error_breadcrumb)
+      feature.new.on_error(request, StandardError.new("sample error"))
+    end
   end
-
-  # TODO: WebMock is not compatible with HTTP errors tracking, need a fix
-  # it "handle errors" do
-  #   stub_request(:get, uri).to_raise(HTTP::ConnectionError)
-  #   expect(Honeybadger).to receive(:add_breadcrumb).with(*expected_request_breadcrumb)
-  #   expect(Honeybadger).to receive(:add_breadcrumb).with("HTTP Request Error")
-  #   expect { HTTP.use(:request_tracking).get("https://test") }.to raise_error(HTTP::ConnectionError)
-  # end
 end


### PR DESCRIPTION
Ensure breadcrumbs metadata is always a flat Hash to match Honeybadger limitations.

<img width="943" alt="image" src="https://github.com/dreikanter/feeder/assets/126636/f162530d-6ea3-4ca1-9524-043c86224c54">

References:

- #491
- https://docs.honeybadger.io/lib/ruby/getting-started/breadcrumbs/#limits