### PR TITLE
Fix Honeybadger breadcrumbs metadata

### DIFF
--- a/app/support/request_tracking.rb
+++ b/app/support/request_tracking.rb
@@ -6,17 +6,17 @@ class RequestTracking < HTTP::Feature
   HTTP::Options.register_feature(:request_tracking, self)
 
   def wrap_request(request)
-    breadcrumb("HTTP Request", request: flatten_request_data(request))
+    breadcrumb("HTTP Request", request_metadata(request))
     request
   end
 
   def wrap_response(response)
-    breadcrumb("HTTP Response", response: response_data(response))
+    breadcrumb("HTTP Response", response_metadata(response))
     response
   end
 
   def on_error(request, error)
-    breadcrumb("HTTP Request Error", request: flatten_request_data(request), error: error.inspect)
+    breadcrumb("HTTP Request Error", request_metadata(request).merge(error: error.inspect))
   end
 
   private
@@ -26,7 +26,7 @@ class RequestTracking < HTTP::Feature
   end
 
   # SEE: https://github.com/httprb/http/blob/main/lib/http/request.rb
-  def flatten_request_data(request)
+  def request_metadata(request)
     {
       verb: request.verb,
       uri: request.uri.to_s,
@@ -35,7 +35,7 @@ class RequestTracking < HTTP::Feature
   end
 
   # SEE: https://github.com/httprb/http/blob/main/lib/http/response.rb
-  def response_data(response)
+  def response_metadata(response)
     {
       status: response.status,
       headers: response.headers.to_h.to_json,

--- a/app/support/request_tracking.rb
+++ b/app/support/request_tracking.rb
@@ -16,13 +16,13 @@ class RequestTracking < HTTP::Feature
   end
 
   def on_error(request, error)
-    breadcrumb("HTTP Request Error", request_metadata(request).merge(error: error.inspect))
+    breadcrumb("HTTP Request Error", request_metadata(request).merge("error"  => error.inspect))
   end
 
   private
 
   def breadcrumb(message, metadata = {})
-    Honeybadger.add_breadcrumb(message, metadata: metadata, category: "request")
+    Honeybadger.add_breadcrumb(message, metadata: metadata.stringify_keys, category: "request")
   end
 
   # SEE: https://github.com/httprb/http/blob/main/lib/http/request.rb

--- a/app/support/request_tracking.rb
+++ b/app/support/request_tracking.rb
@@ -16,7 +16,7 @@ class RequestTracking < HTTP::Feature
   end
 
   def on_error(request, error)
-    breadcrumb("HTTP Request Error", request_metadata(request).merge("error"  => error.inspect))
+    breadcrumb("HTTP Request Error", request_metadata(request).merge("error" => error.inspect))
   end
 
   private

--- a/spec/support/request_tracking_spec.rb
+++ b/spec/support/request_tracking_spec.rb
@@ -31,11 +31,9 @@ RSpec.describe RequestTracking do
         {
           category: "request",
           metadata: {
-            request: {
-              "verb" => "get",
-              "uri" => uri,
-              "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
-            }
+            "verb" => "get",
+            "uri" => uri,
+            "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
           }
         }
       ]
@@ -54,12 +52,10 @@ RSpec.describe RequestTracking do
         {
           category: "request",
           metadata: {
-            response: {
-              "status" => 200,
-              "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json,
-              "proxy_headers" => [].to_json,
-              "version" => "1.1"
-            }
+            "status" => 200,
+            "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json,
+            "proxy_headers" => [].to_json,
+            "version" => "1.1"
           }
         }
       ]
@@ -79,11 +75,9 @@ RSpec.describe RequestTracking do
           category: "request",
           metadata: {
             error: "#<StandardError: sample error>",
-            request: {
-              "verb" => "get",
-              "uri" => uri,
-              "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
-            }
+            "verb" => "get",
+            "uri" => uri,
+            "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
           }
         }
       ]

--- a/spec/support/request_tracking_spec.rb
+++ b/spec/support/request_tracking_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe RequestTracking do
         {
           category: "request",
           metadata: {
-            error: "#<StandardError: sample error>",
+            "error" => "#<StandardError: sample error>",
             "verb" => "get",
             "uri" => uri,
             "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json


### PR DESCRIPTION
Do not use array or Hash values, only scalars.

References:

- #494
- Closes https://github.com/dreikanter/feeder/issues/491
