### PR TITLE
Don't return digest entity from `KotakuDailyProcessor` if no posts

### DIFF
--- a/app/normalizers/kotaku_daily_normalizer.rb
+++ b/app/normalizers/kotaku_daily_normalizer.rb
@@ -14,7 +14,7 @@ class KotakuDailyNormalizer < BaseNormalizer
   end
 
   def attachments
-    [content.first.fetch(:post).image].compact_blank
+    [first_post_image].compact_blank
   end
 
   def comments
@@ -25,6 +25,10 @@ class KotakuDailyNormalizer < BaseNormalizer
   end
 
   private
+
+  def first_post_image
+    content.first&.fetch(:post)&.image
+  end
 
   # :reek:LongParameterList
   def build_comment(title, author, url, comments_count)

--- a/app/processors/kotaku_daily_processor.rb
+++ b/app/processors/kotaku_daily_processor.rb
@@ -8,10 +8,8 @@
 # - Assigns FeedEntity content with the ordered posts array
 class KotakuDailyProcessor < BaseProcessor
   def entities
+    return [] if yesterday_posts.none?
     [build_entity(yesterday.rfc3339, ordered_posts)]
-  rescue StandardError => e
-    Honeybadger.notify(e)
-    []
   end
 
   private
@@ -25,7 +23,7 @@ class KotakuDailyProcessor < BaseProcessor
   end
 
   def yesterday_posts
-    entries.filter { |post| post.published.yesterday? }
+    @yesterday_posts ||= entries.filter { |post| post.published.yesterday? }
   end
 
   def entries

--- a/spec/processors/kotaku_daily_processor_spec.rb
+++ b/spec/processors/kotaku_daily_processor_spec.rb
@@ -40,4 +40,12 @@ RSpec.describe KotakuDailyProcessor do
   it "includes expected posts" do
     expect(first_entity.content.map { |item| item[:post].url }).to eq(expected_post_urls)
   end
+
+  context "when no posts during the day" do
+    before do
+      travel_to(DateTime.parse("2023-06-30 01:00:00 +0000"))
+    end
+
+    it { expect(entities).to be_empty }
+  end
 end


### PR DESCRIPTION
Changes:

- Don't return an entity from `KotakuDailyProcessor` if there were no posts during the day.
- Don't continue feed processing when processor raises.
