### PR TITLE
Stringify Hobeybadger breadcrumbs metadata

### DIFF
--- a/app/support/request_tracking.rb
+++ b/app/support/request_tracking.rb
@@ -2,49 +2,51 @@
 #
 #   HTTP.use(:request_tracking).get("https://example.com/")
 #
+# SEE: https://github.com/httprb/http/blob/main/lib/http/request.rb
+# SEE: https://github.com/httprb/http/blob/main/lib/http/response.rb
+#
 class RequestTracking < HTTP::Feature
   HTTP::Options.register_feature(:request_tracking, self)
 
   def wrap_request(request)
-    breadcrumb("HTTP Request", request_metadata(request))
+    Honeybadger.add_breadcrumb(
+      "HTTP Request",
+      category: "request",
+      metadata: {
+        verb: request.verb.to_s,
+        uri: request.uri.to_s,
+        headers: request.headers.to_h.to_json
+      }
+    )
+
     request
   end
 
   def wrap_response(response)
-    breadcrumb("HTTP Response", response_metadata(response))
+    Honeybadger.add_breadcrumb(
+      "HTTP Response",
+      category: "request",
+      metadata: {
+        status: response.status.to_s,
+        headers: response.headers.to_h.to_json,
+        version: response.version.to_s,
+        proxy_headers: response.proxy_headers.to_json
+      }
+    )
+
     response
   end
 
   def on_error(request, error)
-    breadcrumb("HTTP Request Error", request_metadata(request).merge("error" => error.inspect))
-  end
-
-  private
-
-  def breadcrumb(message, metadata = {})
-    Honeybadger.add_breadcrumb(message, metadata: ensure_primitive_values(metadata), category: "request")
-  end
-
-  def ensure_primitive_values(metadata)
-    metadata.to_h { [_1.to_s, _2.to_s] }
-  end
-
-  # SEE: https://github.com/httprb/http/blob/main/lib/http/request.rb
-  def request_metadata(request)
-    {
-      verb: request.verb,
-      uri: request.uri.to_s,
-      headers: request.headers.to_h.to_json
-    }.as_json
-  end
-
-  # SEE: https://github.com/httprb/http/blob/main/lib/http/response.rb
-  def response_metadata(response)
-    {
-      status: response.status,
-      headers: response.headers.to_h.to_json,
-      version: response.version,
-      proxy_headers: response.proxy_headers.to_json
-    }.as_json
+  Honeybadger.add_breadcrumb(
+      "HTTP Request Error",
+      category: "request",
+      metadata: {
+        error: error.inspect,
+        verb: request.verb.to_s,
+        uri: request.uri.to_s,
+        headers: request.headers.to_h.to_json
+      }
+    )
   end
 end

--- a/app/support/request_tracking.rb
+++ b/app/support/request_tracking.rb
@@ -9,44 +9,39 @@ class RequestTracking < HTTP::Feature
   HTTP::Options.register_feature(:request_tracking, self)
 
   def wrap_request(request)
-    Honeybadger.add_breadcrumb(
-      "HTTP Request",
-      category: "request",
-      metadata: {
-        verb: request.verb.to_s,
-        uri: request.uri.to_s,
-        headers: request.headers.to_h.to_json
-      }
-    )
-
+    breadcrumb("HTTP Request", request_metadata(request))
     request
   end
 
   def wrap_response(response)
-    Honeybadger.add_breadcrumb(
-      "HTTP Response",
-      category: "request",
-      metadata: {
-        status: response.status.to_s,
-        headers: response.headers.to_h.to_json,
-        version: response.version.to_s,
-        proxy_headers: response.proxy_headers.to_json
-      }
-    )
-
+    breadcrumb("HTTP Response", response_metadata(response))
     response
   end
 
   def on_error(request, error)
-  Honeybadger.add_breadcrumb(
-      "HTTP Request Error",
-      category: "request",
-      metadata: {
-        error: error.inspect,
-        verb: request.verb.to_s,
-        uri: request.uri.to_s,
-        headers: request.headers.to_h.to_json
-      }
-    )
+    breadcrumb("HTTP Request Error", request_metadata(request).merge(error: error.inspect))
+  end
+
+  private
+
+  def breadcrumb(message, metadata)
+    Honeybadger.add_breadcrumb(message, category: "request", metadata: metadata)
+  end
+
+  def request_metadata(request)
+    {
+      verb: request.verb.to_s,
+      uri: request.uri.to_s,
+      headers: JSON.pretty_generate(request.headers.to_h)
+    }
+  end
+
+  def response_metadata(response)
+    {
+      code: response.status.code,
+      headers: JSON.pretty_generate(response.headers.to_h),
+      version: response.version.to_s,
+      proxy_headers: JSON.pretty_generate(response.proxy_headers.to_h)
+    }
   end
 end

--- a/spec/support/request_tracking_spec.rb
+++ b/spec/support/request_tracking_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe RequestTracking do
         {
           category: "request",
           metadata: {
-            "verb" => "get",
-            "uri" => uri,
-            "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
+            verb: "get",
+            uri: uri,
+            headers: JSON.pretty_generate({"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"})
           }
         }
       ]
@@ -52,10 +52,10 @@ RSpec.describe RequestTracking do
         {
           category: "request",
           metadata: {
-            "status" => "200",
-            "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json,
-            "proxy_headers" => [].to_json,
-            "version" => "1.1"
+            code: 200,
+            headers: JSON.pretty_generate({"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}),
+            proxy_headers: JSON.pretty_generate({}),
+            version: "1.1"
           }
         }
       ]
@@ -74,10 +74,10 @@ RSpec.describe RequestTracking do
         {
           category: "request",
           metadata: {
-            "error" => "#<StandardError: sample error>",
-            "verb" => "get",
-            "uri" => uri,
-            "headers" => {"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"}.to_json
+            error: "#<StandardError: sample error>",
+            verb: "get",
+            uri: uri,
+            headers: JSON.pretty_generate({"Content-Type" => "application/json", "Host" => "example.com", "User-Agent" => "http.rb/5.1.1"})
           }
         }
       ]


### PR DESCRIPTION
`response.status` was a non-primitive object.

References:

- https://github.com/dreikanter/feeder/issues/491