### PR TITLE
Do not import `wumo` posts with no image

### DIFF
--- a/app/normalizers/wumo_normalizer.rb
+++ b/app/normalizers/wumo_normalizer.rb
@@ -11,12 +11,22 @@ class WumoNormalizer < RssNormalizer
   end
 
   def attachments
-    [image_url]
+    first_image_url ? [first_image_url] : []
+  end
+
+  def validation_errors
+    super.tap do |errors|
+      errors << "missing image" unless first_image_url
+    end
   end
 
   private
 
-  def image_url
-    Nokogiri::HTML(content.description).css("img:first").first[:src]
+  def first_image_url
+    @first_image_url ||= first_image.try(:[], :src)
+  end
+
+  def first_image
+    Nokogiri::HTML(content.description).css("img:first").first
   end
 end

--- a/spec/fixtures/files/feeds/wumo/feed.xml
+++ b/spec/fixtures/files/feeds/wumo/feed.xml
@@ -1,0 +1,25 @@
+<rss
+  xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <atom:link href="http://wumo.com/wumo?view=rss" rel="self" type="application/rss+xml" />
+    <title>Wumo</title>
+    <link>http://wumo.com/wumo</link>
+    <description>Wumo is created by new creations.</description>
+    <item>
+      <title>Wumo 28. Jul 2023</title>
+      <guid>http://wumo.com/wumo/2023/07/28</guid>
+      <link>http://wumo.com/wumo/2023/07/28</link>
+      <description>
+        <![CDATA[
+            <a href="http://wumo.com/wumo/2023/07/28"><img src="http://wumo.com/img/wumo/2023/07/wumo64abf9be2497a4.68979190.jpg" alt="Wumo 28. Jul 2023" /></a>
+            ]]>
+      </description>
+    </item>
+    <item>
+      <title>Wumo 27. Jul 2023</title>
+      <guid>http://wumo.com/wumo/2023/07/27</guid>
+      <link>http://wumo.com/wumo/2023/07/27</link>
+      <description></description>
+    </item>
+  </channel>
+</rss>

--- a/spec/fixtures/files/feeds/wumo/normalized.json
+++ b/spec/fixtures/files/feeds/wumo/normalized.json
@@ -1,0 +1,34 @@
+[
+  {
+    "feed_id": 17434,
+    "uid": "http://wumo.com/wumo/2023/07/28",
+    "link": "http://wumo.com/wumo/2023/07/28",
+    "published_at": "2023-07-28 00:00:00 +0000",
+    "text": "Wumo 28. Jul 2023 - http://wumo.com/wumo/2023/07/28",
+    "attachments": [
+      "http://wumo.com/img/wumo/2023/07/wumo64abf9be2497a4.68979190.jpg"
+    ],
+    "comments": [
+
+    ],
+    "validation_errors": [
+
+    ]
+  },
+  {
+    "feed_id": 17434,
+    "uid": "http://wumo.com/wumo/2023/07/27",
+    "link": "http://wumo.com/wumo/2023/07/27",
+    "published_at": "2023-07-27 00:00:00 +0000",
+    "text": "Wumo 27. Jul 2023 - http://wumo.com/wumo/2023/07/27",
+    "attachments": [
+
+    ],
+    "comments": [
+
+    ],
+    "validation_errors": [
+      "missing image"
+    ]
+  }
+]

--- a/spec/normalizers/tumblr_normalizer_spec.rb
+++ b/spec/normalizers/tumblr_normalizer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TumblrNormalizer do
         loader: "http",
         processor: "rss",
         normalizer: "tumblr",
-        url: "https://kimchicuddles.com/rss"
+        url: "https://example.com/rss"
       )
     end
 

--- a/spec/normalizers/wumo_normalizer_spec.rb
+++ b/spec/normalizers/wumo_normalizer_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require "support/shared_examples_a_normalizer"
+
+RSpec.describe WumoNormalizer do
+  it_behaves_like "a normalizer" do
+    let(:feed) do
+      create(
+        :feed,
+        name: "wumo",
+        url: "https://wumo.com/wumo?view=rss",
+        loader: "http",
+        processor: "rss",
+        normalizer: "wumo"
+      )
+    end
+
+    let(:feed_fixture) { "feeds/wumo/feed.xml" }
+    let(:normalized_fixture) { "feeds/wumo/normalized.json" }
+  end
+end

--- a/spec/support/shared_examples_a_normalizer.rb
+++ b/spec/support/shared_examples_a_normalizer.rb
@@ -24,6 +24,19 @@ RSpec.shared_examples "a normalizer" do
     stub_request(:get, feed.url).to_return(body: file_fixture(feed_fixture).read)
   end
 
-  it { expect(feed.normalizer_class).to eq(described_class) }
-  it { expect(normalized_entries.as_json).to eq(expected_normalized_entries) }
+  it "resolves" do
+    expect(feed.normalizer_class).to eq(described_class)
+  end
+
+  it "matches the expected result" do
+    print_actual_data_if_no_match
+    expect(normalized_entries.as_json).to eq(expected_normalized_entries)
+  end
+
+  def print_actual_data_if_no_match
+    if normalized_entries.as_json != expected_normalized_entries
+      hr = "\n#{"-" * 20}\n"
+      puts hr + JSON.pretty_generate(normalized_entries.as_json) + hr
+    end
+  end
 end


### PR DESCRIPTION
Changes:

- New `wumo` validation rule.
- Test cov.
- Print actual normalizer result when it doesn't match to simplify expected data update.