### PR TITLE
Remove stale posts tracking from `NormalizedEntity`

### DIFF
--- a/app/models/normalized_entity.rb
+++ b/app/models/normalized_entity.rb
@@ -28,11 +28,6 @@ class NormalizedEntity
     as_json == other.as_json
   end
 
-  # @return [true, false] true if the entity is older than feed import threshold ("after")
-  def stale?
-    feed_after.present? && (published_at_or_default < feed_after)
-  end
-
   def find_or_create_post
     existing_post || create_post
   end
@@ -71,10 +66,6 @@ class NormalizedEntity
 
   def published_at_or_default
     published_at ? published_at.to_datetime : DateTime.now
-  end
-
-  def feed_after
-    feed.after
   end
 
   def feed

--- a/app/normalizers/base_normalizer.rb
+++ b/app/normalizers/base_normalizer.rb
@@ -54,10 +54,19 @@ class BaseNormalizer
   end
 
   def validation_errors
-    @validation_errors ||= []
+    @validation_errors ||= base_validation_errors
   end
 
   private
+
+  def base_validation_errors
+    stale? ? ["stale"] : []
+  end
+
+  # @return [true, false] true if the entity is older than the import threshold
+  def stale?
+    feed_after && feed_after > published_at
+  end
 
   def add_error(error)
     validation_errors << error
@@ -68,5 +77,5 @@ class BaseNormalizer
   end
 
   delegate :uid, :content, :feed, to: :entity
-  delegate :options, to: :feed, prefix: :feed
+  delegate :options, :after, to: :feed, prefix: :feed
 end

--- a/app/processors/atom_processor.rb
+++ b/app/processors/atom_processor.rb
@@ -1,7 +1,7 @@
 require "rss"
 
 class AtomProcessor < BaseProcessor
-  def entities
+  def process
     parse_content.map { build_entity(_1.link.href, _1) }
   end
 

--- a/app/processors/base_processor.rb
+++ b/app/processors/base_processor.rb
@@ -7,7 +7,7 @@ class BaseProcessor
   end
 
   # @return [Array<FeedEntity>] array of entities generated from the content
-  def entities
+  def process
     raise AbstractMethodError
   end
 

--- a/app/processors/feedjira_processor.rb
+++ b/app/processors/feedjira_processor.rb
@@ -1,5 +1,5 @@
 class FeedjiraProcessor < BaseProcessor
-  def entities
+  def process
     parse_content.map { build_entity(_1.url, _1) }
   end
 

--- a/app/processors/hackernews_processor.rb
+++ b/app/processors/hackernews_processor.rb
@@ -1,7 +1,7 @@
 class HackernewsProcessor < BaseProcessor
   SCORE_THRESHOLD = 300
 
-  def entities
+  def process
     above_score_threshold.map { build_entity(_1.fetch("id"), _1) }
   end
 

--- a/app/processors/kotaku_daily_processor.rb
+++ b/app/processors/kotaku_daily_processor.rb
@@ -7,7 +7,7 @@
 # - Assigns FeedEntity uid with a serialized publication date
 # - Assigns FeedEntity content with the ordered posts array
 class KotakuDailyProcessor < BaseProcessor
-  def entities
+  def process
     return [] if yesterday_posts.none?
     [build_entity(yesterday.rfc3339, ordered_posts)]
   end

--- a/app/processors/lobsters_processor.rb
+++ b/app/processors/lobsters_processor.rb
@@ -1,5 +1,5 @@
 class LobstersProcessor < FeedjiraProcessor
-  def entities
+  def process
     parse_content.map { build_entity(_1.entry_id, _1) }
   end
 end

--- a/app/processors/nitter_processor.rb
+++ b/app/processors/nitter_processor.rb
@@ -1,5 +1,5 @@
 class NitterProcessor < FeedjiraProcessor
-  def entities
+  def process
     parse_content.map { build_entity(NitterPermalink.call(_1.url), _1) }
   end
 end

--- a/app/processors/reddit_processor.rb
+++ b/app/processors/reddit_processor.rb
@@ -2,7 +2,7 @@ class RedditProcessor < BaseProcessor
   SCORE_THRESHOLD = 2000
   POST_SCORE_CACHE_TTL = 2.hours
 
-  def entities
+  def process
     atom_feed_entries.select { above_score_threshold?(_1.uid) }
   end
 

--- a/app/processors/rss_processor.rb
+++ b/app/processors/rss_processor.rb
@@ -1,5 +1,5 @@
 class RssProcessor < BaseProcessor
-  def entities
+  def process
     items = RSS::Parser.parse(content).try(:items)
     (items || []).map { build_entity(_1.link, _1) }
   end

--- a/app/processors/youtube_processor.rb
+++ b/app/processors/youtube_processor.rb
@@ -1,5 +1,5 @@
 class YoutubeProcessor < BaseProcessor
-  def entities
+  def process
     parse_content.map { build_entity(_1.url, _1) }
   end
 

--- a/app/services/pull.rb
+++ b/app/services/pull.rb
@@ -5,16 +5,12 @@ class Pull
   param :feed
 
   def call
-    normalized_entities.reject(&:stale?)
+    new_entities.filter_map { normalize_entity(_1) }
   end
 
   private
 
   delegate :loader_class, :processor_class, :normalizer_class, :import_limit_or_default, to: :feed
-
-  def normalized_entities
-    new_entities.filter_map { normalize_entity(_1) }
-  end
 
   def new_entities
     entities.filter { existing_uids.exclude?(_1.uid) }

--- a/app/services/pull.rb
+++ b/app/services/pull.rb
@@ -29,7 +29,7 @@ class Pull
   end
 
   def load_entities
-    all_entities = processor_class.new(content: loader_class.new(feed).content, feed: feed).entities
+    all_entities = processor_class.new(content: loader_class.new(feed).content, feed: feed).process
     return all_entities.take(import_limit_or_default) if import_limit_or_default.positive?
     all_entities
   end

--- a/spec/models/normalized_entity_spec.rb
+++ b/spec/models/normalized_entity_spec.rb
@@ -9,24 +9,6 @@ RSpec.describe NormalizedEntity do
 
   before { freeze_time }
 
-  describe "#stale?" do
-    it "returns false for recent timestamps" do
-      expect(normalized_entry(published_at: one_day.seconds.ago)).not_to be_stale
-    end
-
-    it "returns true for old timestamps" do
-      expect(normalized_entry(published_at: one_day.succ.seconds.ago)).to be_stale
-    end
-
-    it "returns false with undefined (default) timestamp" do
-      expect(normalized_entry).not_to be_stale
-    end
-
-    def normalized_entry(attributes = {})
-      model.new(feed_id: feed.id, **attributes)
-    end
-  end
-
   describe "#==" do
     let(:instance) { model.new }
 

--- a/spec/normalizers/aerostat_normalizer_spec.rb
+++ b/spec/normalizers/aerostat_normalizer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AerostatNormalizer do
 
   let(:feed) { build(:feed, import_limit: 0) }
   let(:content) { file_fixture("feeds/aerostat/feed.xml").read }
-  let(:entities) { FeedjiraProcessor.new(content: content, feed: feed).entities }
+  let(:entities) { FeedjiraProcessor.new(content: content, feed: feed).process }
 
   let(:expected) do
     JSON.parse(file_fixture("feeds/aerostat/normalized.json").read).tap do |data|

--- a/spec/normalizers/base_normalizer_spec.rb
+++ b/spec/normalizers/base_normalizer_spec.rb
@@ -86,4 +86,14 @@ RSpec.describe BaseNormalizer do
       expect(concrete_normalizer.call(feed_entity).comments).to be_blank
     end
   end
+
+  context "with stale entities" do
+    let(:concrete_normalizer) { Class.new(subject) }
+
+    before { feed.after = 1.second.from_now }
+
+    it "adds stale validation error" do
+      expect(concrete_normalizer.new(feed_entity).validation_errors).to eq(["stale"])
+    end
+  end
 end

--- a/spec/normalizers/commitstrip_normalizer_spec.rb
+++ b/spec/normalizers/commitstrip_normalizer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CommitstripNormalizer do
 
   let(:feed) { build(:feed, import_limit: 0) }
   let(:content) { file_fixture("feeds/commitstrip/feed.xml").read }
-  let(:entities) { FeedjiraProcessor.new(content: content, feed: feed).entities }
+  let(:entities) { FeedjiraProcessor.new(content: content, feed: feed).process }
   let(:entity_with_html_entities) { entities[4] }
 
   let(:expected_entity) do

--- a/spec/normalizers/hackernews_normalizer_spec.rb
+++ b/spec/normalizers/hackernews_normalizer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe HackernewsNormalizer do
   let(:feed) { create(:feed, :hackernews) }
 
   let(:result) { entities.map { |entity| normalizer.call(entity) }.as_json }
-  let(:entities) { HackernewsProcessor.new(content: content, feed: feed).entities }
+  let(:entities) { HackernewsProcessor.new(content: content, feed: feed).process }
   let(:content) { HackernewsLoader.new(feed).content }
 
   let(:expected) do

--- a/spec/normalizers/kotaku_daily_normalizer_spec.rb
+++ b/spec/normalizers/kotaku_daily_normalizer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe KotakuDailyNormalizer do
 
   let(:feed) { create(:feed, :kotaku_daily) }
   let(:content) { feed.loader_class.new(feed).content }
-  let(:entities) { feed.processor_class.new(content: content, feed: feed).entities }
+  let(:entities) { feed.processor_class.new(content: content, feed: feed).process }
   let(:normalized_entries) { entities.map { |entity| normalizer.call(entity) } }
 
   let(:expected) do

--- a/spec/normalizers/nextbigfuture_normalizer_spec.rb
+++ b/spec/normalizers/nextbigfuture_normalizer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NextbigfutureNormalizer do
   end
 
   let(:content) { file_fixture("feeds/nextbigfuture/feed.xml").read }
-  let(:entities) { feed.processor_class.new(content: content, feed: feed).entities }
+  let(:entities) { feed.processor_class.new(content: content, feed: feed).process }
   let(:normalized_entries) { entities.map { normalizer.call(_1) } }
 
   let(:expected_entity) do

--- a/spec/normalizers/nitter_normalizer_spec.rb
+++ b/spec/normalizers/nitter_normalizer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe NitterNormalizer do
     )
   end
 
-  let(:entities) { FeedjiraProcessor.new(content: content, feed: feed).entities }
+  let(:entities) { FeedjiraProcessor.new(content: content, feed: feed).process }
   let(:content) { file_fixture("feeds/nitter/rss.xml").read }
 
   let(:tweet_with_image) { entities[0] }

--- a/spec/processors/base_processor_spec.rb
+++ b/spec/processors/base_processor_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe BaseProcessor do
 
   let(:concrete_processor) do
     Class.new(processor) do
-      define_method(:entities) { %w[SAMPLE_ENTITY] }
+      define_method(:process) { %w[SAMPLE_ENTITY] }
     end
   end
 
-  it { expect { processor.new(content: nil, feed: feed).entities }.to raise_error(StandardError) }
-  it { expect(concrete_processor.new(content: nil, feed: feed).entities).to eq(%w[SAMPLE_ENTITY]) }
+  it { expect { processor.new(content: nil, feed: feed).process }.to raise_error(AbstractMethodError) }
+  it { expect(concrete_processor.new(content: nil, feed: feed).process).to eq(%w[SAMPLE_ENTITY]) }
 end

--- a/spec/processors/hackernews_processor_spec.rb
+++ b/spec/processors/hackernews_processor_spec.rb
@@ -4,7 +4,7 @@ require "support/shared_hackernews_stubs"
 RSpec.describe HackernewsProcessor do
   subject(:processor) { described_class }
 
-  let(:entities) { processor.new(content: content, feed: feed).entities }
+  let(:entities) { processor.new(content: content, feed: feed).process }
   let(:feed) { create(:feed, :hackernews) }
   let(:content) { HackernewsLoader.new(feed).content }
   let(:expected_content) { JSON.parse(file_fixture("feeds/hackernews/expected_processor_result.json").read) }

--- a/spec/processors/kotaku_daily_processor_spec.rb
+++ b/spec/processors/kotaku_daily_processor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe KotakuDailyProcessor do
   let(:feed) { create(:feed, :kotaku_daily) }
 
   let(:content) { feed.loader_class.new(feed).content }
-  let(:entities) { processor.new(content: content, feed: feed).entities }
+  let(:entities) { processor.new(content: content, feed: feed).process }
   let(:first_entity) { entities.first }
   let(:expected_post_urls) { JSON.parse(file_fixture("feeds/kotaku_daily/expected_post_urls.json").read) }
   let(:expected_comment_counts) { JSON.parse(file_fixture("feeds/kotaku_daily/expected_comment_counts.json").read) }

--- a/spec/processors/nitter_processor_spec.rb
+++ b/spec/processors/nitter_processor_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NitterProcessor do
   subject(:processor) { described_class }
 
   let(:content) { file_fixture("feeds/nitter/rss.xml").read }
-  let(:entities) { processor.new(content: content, feed: feed).entities }
+  let(:entities) { processor.new(content: content, feed: feed).process }
 
   let(:feed) do
     build(

--- a/spec/processors/reddit_processor_spec.rb
+++ b/spec/processors/reddit_processor_spec.rb
@@ -28,34 +28,34 @@ RSpec.describe RedditProcessor do
 
   it "fetches reddit points" do
     stub_posts_score_request
-    expect(entities.map(&:uid)).to eq(expected_uids)
+    expect(feed_entities.map(&:uid)).to eq(expected_uids)
   end
 
   it "caches posts score to prevent repeating HTTP requests too soon" do
     stub = stub_posts_score_request
-    entities
+    feed_entities
     remove_request_stub(stub)
-    expect { entities }.not_to raise_error
+    expect { feed_entities }.not_to raise_error
   end
 
   it "expires cache" do
     travel_to(4.hours.ago) do
       stub = stub_posts_score_request
-      entities
+      feed_entities
       remove_request_stub(stub)
     end
 
     # NOTE: Attempt to fetch fresh data after cache expired
-    expect { entities }.to raise_error(WebMock::NetConnectNotAllowedError)
+    expect { feed_entities }.to raise_error(WebMock::NetConnectNotAllowedError)
   end
 
   it "ignores posts on score service error" do
     stub_request(:get, thread_url).to_return(status: 404)
-    expect(entities).to be_empty
+    expect(feed_entities).to be_empty
   end
 
-  def entities
-    processor.new(content: content, feed: feed).entities
+  def feed_entities
+    processor.new(content: content, feed: feed).process
   end
 
   def stub_posts_score_request

--- a/spec/services/pull_spec.rb
+++ b/spec/services/pull_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 class TestProcessor < BaseProcessor
-  def entities
+  def process
     JSON.parse(content).map { build_entity(_1.fetch("link"), _1) }
   end
 end

--- a/spec/support/faulty_processor.rb
+++ b/spec/support/faulty_processor.rb
@@ -1,5 +1,5 @@
 class FaultyProcessor < BaseProcessor
-  def entities
+  def process
     raise "test error"
   end
 end

--- a/spec/support/test_processor.rb
+++ b/spec/support/test_processor.rb
@@ -1,5 +1,5 @@
 class TestProcessor < BaseProcessor
-  def entities
+  def process
     [
       FeedEntity.new(uid: "1", content: "", feed: Feed.new),
       FeedEntity.new(uid: "2", content: "", feed: Feed.new)


### PR DESCRIPTION
- Make the `BaseNormalizer` validations track stale posts.
- Rename `BaseProcessor#entities` to `#process` (service refactoring preparation).

References:

- #502