### PR TITLE
Extract configuration to a separate Rake task

### DIFF
--- a/lib/tasks/pull.rake
+++ b/lib/tasks/pull.rake
@@ -1,28 +1,28 @@
 namespace :feeder do
-  desc 'Pull one specific feed: "rake feeder:pull[feed_name]"'
-  task pull: :environment do |_task, args|
+  desc "Update feeds configuration"
+  task configuration: :environment do
+    FeedsConfiguration.sync
+  end
+
+  desc "Pull one specific feed: rake feeder:pull[feed_name]"
+  task pull: :configuration do |_task, args|
     # TODO: Move to a service
     feed_name = args.extras[0]
     raise "feed name is required" unless feed_name
-    FeedsConfiguration.sync
     feed = Feed.enabled.find_by(name: feed_name)
     raise "specified feed does not exist or enabled" unless feed
     ProcessFeed.new(feed).process
   end
 
   desc "Pull all feeds"
-  task pull_all: :environment do
-    FeedsConfiguration.sync
+  task pull_all: :configuration do
     Feed.enabled.each { |feed| ProcessFeed.new(feed).process }
   end
 
   desc "Pull stale feeds"
-  task pull_stale: :environment do
+  task pull_stale: :configuration do
     # TODO: Move to a service
-    FeedsConfiguration.sync
     feeds = Feed.enabled.stale
-    feed_names = feeds.pluck(:name).join(", ")
-    Rails.logger.info("---> updating #{feeds.count} feed(s): #{feed_names}")
     feeds.each { |feed| ProcessFeed.new(feed).process }
   end
 end


### PR DESCRIPTION
Using Rake prerequisites to avoid repeating `FeederConfiguration.sync` call before each task.