### PR TITLE
F2: Implement Publisher service

### DIFF
--- a/app/services/batch_publisher.rb
+++ b/app/services/batch_publisher.rb
@@ -16,11 +16,16 @@ class BatchPublisher
 
     posts.each do |post|
       logger.info("publishing post: #{post.id}")
+      publish_post(post)
+    end
+  end
 
-      post.with_lock do
-        next unless post.reload.enqueued?
-        PostPublisher.new(post: post, freefeed_client: freefeed_client).publish
-      end
+  private
+
+  def publish_post(post)
+    post.with_lock do
+      next unless post.reload.enqueued?
+      PostPublisher.new(post: post, freefeed_client: freefeed_client).publish
     end
   end
 end

--- a/app/services/feed_processor.rb
+++ b/app/services/feed_processor.rb
@@ -23,9 +23,11 @@ class FeedProcessor
   private
 
   def build_freefeed_client
+    feeder = Rails.configuration.feeder
+
     Freefeed::Client.new(
-      token: Rails.configuration.feeder.freefeed_token,
-      base_url: Rails.configuration.feeder.freefeed_base_url
+      token: feeder.freefeed_token,
+      base_url: feeder.freefeed_base_url
     )
   end
 end

--- a/app/services/feed_processor.rb
+++ b/app/services/feed_processor.rb
@@ -14,8 +14,18 @@ class FeedProcessor
   def perform
     feeds.each do |feed|
       Importer.new(feed).import
-      Publisher.new(posts: feed.posts.pending).publish
+      Publisher.new(posts: feed.posts.pending, freefeed_client: build_freefeed_client).publish
+
       # TBD: Handle errors
     end
+  end
+
+  private
+
+  def build_freefeed_client
+    Freefeed::Client.new(
+      token: Rails.configuration.feeder.freefeed_token,
+      base_url: Rails.configuration.feeder.freefeed_base_url
+    )
   end
 end

--- a/app/services/post_publisher.rb
+++ b/app/services/post_publisher.rb
@@ -8,6 +8,7 @@ class PostPublisher
     @freefeed_client = freefeed_client
   end
 
+  # TBD :reek:TooManyStatements
   def publish
     attachment_ids = create_attachments
     post_id = create_post(attachment_ids)

--- a/app/services/post_publisher.rb
+++ b/app/services/post_publisher.rb
@@ -1,0 +1,60 @@
+class PostPublisher
+  include Logging
+
+  attr_reader :post, :freefeed_client
+
+  def initialize(post:, freefeed_client:)
+    @post = post
+    @freefeed_client = freefeed_client
+  end
+
+  def publish
+    attachment_ids = create_attachments
+    post_id = create_post(attachment_ids)
+    post.update(freefeed_post_id: post_id)
+    create_comments(post_id)
+    post.success!
+    logger.info("---> new post URL: #{post.permalink}")
+  rescue StandardError
+    post.fail!
+    # TBD: Report error
+  end
+
+  private
+
+  def create_post(attachment_ids)
+    response = freefeed_client.create_post(
+      post: {
+        body: post.text,
+        attachments: attachment_ids
+      },
+      meta: {
+        feeds: [post.feed.name]
+      }
+    )
+
+    response.parse.dig("posts", "id")
+  end
+
+  def create_comments(post_id)
+    post.comments.each do |comment|
+      freefeed_client.create_comment(
+        comment: {
+          body: comment,
+          postId: post_id
+        }
+      )
+    end
+  end
+
+  def create_attachments
+    post.attachments.map { |url| create_attachment(url) }
+  end
+
+  def create_attachment(url)
+    Downloader.call(url) do |io, content_type|
+      response = freefeed_client.create_attachment(io, content_type: content_type)
+      response.parse.fetch("attachments").fetch("id")
+    end
+  end
+end

--- a/app/services/publisher.rb
+++ b/app/services/publisher.rb
@@ -1,8 +1,14 @@
+# Takes a collection of posts, publishes each, updates post status.
+# Does not interrupt on publication error.
+#
 class Publisher
   include Logging
 
-  def initialize(posts:)
+  attr_reader :posts, :freefeed_client
+
+  def initialize(posts:, freefeed_client:)
     @posts = posts
+    @freefeed_client = freefeed_client
   end
 
   def publish

--- a/config/feeder.yml
+++ b/config/feeder.yml
@@ -1,5 +1,7 @@
 shared:
-  freefeed_base_url: "<%= ENV['FREEFEED_BASE_URL'] || 'https://candy.freefeed.net' %>"
+  freefeed_base_url: "<%= ENV.fetch('FREEFEED_BASE_URL') { 'https://candy.freefeed.net' } %>"
+  freefeed_token: "<%= ENV.fetch('FREEFEED_TOKEN') %>"
+
   feeds:
   - name: "xkcd"
     state: "enabled"

--- a/lib/freefeed/authenticated_request.rb
+++ b/lib/freefeed/authenticated_request.rb
@@ -3,7 +3,7 @@ module Freefeed
     private
 
     def headers
-      super.merge(authorization: "Bearer #{client.token}")
+      super.merge(authorization: "Bearer #{token}")
     end
   end
 end

--- a/lib/freefeed/client.rb
+++ b/lib/freefeed/client.rb
@@ -10,9 +10,14 @@ module Freefeed
 
     attr_reader :token, :base_url
 
-    def initialize(token:, base_url: Freefeed::BASE_URL)
+    def initialize(token:, base_url: Freefeed::BASE_URL, http_client: nil)
       @token = token
       @base_url = base_url
+      @http_client = http_client
+    end
+
+    def http_client
+      @http_client ||= HTTP.follow(max_hops: 3).timeout(5)
     end
   end
 end

--- a/lib/freefeed/downloader.rb
+++ b/lib/freefeed/downloader.rb
@@ -2,10 +2,9 @@ module Freefeed
   class Downloader
     attr_reader :url
 
-    def initialize(url:, max_hops: 3, timeout_seconds: 5)
+    def initialize(url:, http_client: nil)
       @url = url
-      @max_hops = max_hops
-      @timeout_seconds = timeout_seconds
+      @http_client = http_client
     end
 
     def call
@@ -26,17 +25,14 @@ module Freefeed
     end
 
     def fetch_url
-      http.get(url)
+      http_client.get(url)
     rescue StandardError
       # TBD: Report download error
       nil
     end
 
-    def http
-      HTTP
-        .use(:request_tracking)
-        .follow(max_hops: max_hops)
-        .timeout(timeout_seconds)
+    def http_client
+      @http_client ||= HTTP.follow(max_hops: max_hops).timeout(timeout_seconds)
     end
   end
 end

--- a/lib/freefeed/downloader.rb
+++ b/lib/freefeed/downloader.rb
@@ -1,0 +1,42 @@
+module Freefeed
+  class Downloader
+    attr_reader :url
+
+    def initialize(url:, max_hops: 3, timeout_seconds: 5)
+      @url = url
+      @max_hops = max_hops
+      @timeout_seconds = timeout_seconds
+    end
+
+    def call
+      # TBD: Honeybadger.context(downloader: {url: url})
+      response = fetch_url
+      return unless response&.status&.success?
+      yield build_io_from(response), response.content_type.mime_type
+    end
+
+    private
+
+    def build_io_from(response)
+      StringIO.new.tap do |io|
+        io.set_encoding(Encoding::BINARY)
+        io.write(response.body.to_s)
+        io.rewind
+      end
+    end
+
+    def fetch_url
+      http.get(url)
+    rescue StandardError
+      # TBD: Report download error
+      nil
+    end
+
+    def http
+      HTTP
+        .use(:request_tracking)
+        .follow(max_hops: max_hops)
+        .timeout(timeout_seconds)
+    end
+  end
+end

--- a/lib/freefeed/downloader.rb
+++ b/lib/freefeed/downloader.rb
@@ -1,6 +1,6 @@
 module Freefeed
   class Downloader
-    attr_reader :url
+    attr_reader :url, :http_client
 
     def initialize(url:, http_client: nil)
       @url = url
@@ -29,10 +29,6 @@ module Freefeed
     rescue StandardError
       # TBD: Report download error
       nil
-    end
-
-    def http_client
-      @http_client ||= HTTP.follow(max_hops: max_hops).timeout(timeout_seconds)
     end
   end
 end

--- a/lib/freefeed/downloader.rb
+++ b/lib/freefeed/downloader.rb
@@ -2,7 +2,7 @@ module Freefeed
   class Downloader
     attr_reader :url, :http_client
 
-    def initialize(url:, http_client: nil)
+    def initialize(url:, http_client:)
       @url = url
       @http_client = http_client
     end

--- a/lib/freefeed/request.rb
+++ b/lib/freefeed/request.rb
@@ -1,10 +1,9 @@
 module Freefeed
   class Request
-    attr_reader :base_url, :http_client, :request_method, :path, :payload
+    attr_reader :client, :request_method, :path, :payload
 
-    def initialize(http_client:, base_url:, request_method:, path:, payload: {})
-      @base_url = base_url
-      @http_client = http_client
+    def initialize(client:, request_method:, path:, payload: {})
+      @client = client
       @request_method = request_method
       @path = path
       @payload = payload
@@ -35,5 +34,7 @@ module Freefeed
         user_agent: "feeder"
       }
     end
+
+    delegate :token, :base_url, :http_client, to: :client, private: true
   end
 end

--- a/lib/freefeed/utils.rb
+++ b/lib/freefeed/utils.rb
@@ -1,21 +1,21 @@
 module Freefeed
   module Utils
-    def authenticated_request(request_method, path, params = {})
+    def authenticated_request(request_method, path, payload = {})
       AuthenticatedRequest.new(
         client: self,
         request_method: request_method,
         path: path,
-        options: params
-      ).call
+        payload: payload
+      ).perform
     end
 
-    def request(request_method, path, params = {})
+    def request(request_method, path, payload = {})
       Request.new(
         client: self,
         request_method: request_method,
         path: path,
-        options: params
-      ).call
+        payload: payload
+      ).perform
     end
   end
 end

--- a/lib/freefeed/v1/attachments.rb
+++ b/lib/freefeed/v1/attachments.rb
@@ -9,7 +9,7 @@ module Freefeed
       end
 
       def create_attachment_from(url:, **)
-        ::Freefeed::Downloader.new(url: url, **).call do |io, content_type|
+        ::Freefeed::Downloader.new(url: url, http_client: http_client, **).call do |io, content_type|
           response = create_attachment(io, content_type: content_type)
           response.parse.fetch("attachments").fetch("id")
         end

--- a/lib/freefeed/v1/attachments.rb
+++ b/lib/freefeed/v1/attachments.rb
@@ -4,8 +4,8 @@ module Freefeed
       # @param [String, Pathname, IO] source could by a file path
       # or an IO object
       def create_attachment(source, content_type: nil)
-        options = {form: {file: file(source, content_type)}}
-        authenticated_request(:post, "/v1/attachments", options)
+        payload = {form: {file: file(source, content_type)}}
+        authenticated_request(:post, "/v1/attachments", payload)
       end
 
       def create_attachment_from(url:, **)

--- a/lib/freefeed/v1/attachments.rb
+++ b/lib/freefeed/v1/attachments.rb
@@ -8,8 +8,8 @@ module Freefeed
         authenticated_request(:post, "/v1/attachments", payload)
       end
 
-      def create_attachment_from(url:, **)
-        ::Freefeed::Downloader.new(url: url, http_client: http_client, **).call do |io, content_type|
+      def create_attachment_from(url:)
+        ::Freefeed::Downloader.new(url: url, http_client: http_client).call do |io, content_type|
           response = create_attachment(io, content_type: content_type)
           response.parse.fetch("attachments").fetch("id")
         end

--- a/lib/freefeed/v1/attachments.rb
+++ b/lib/freefeed/v1/attachments.rb
@@ -8,6 +8,13 @@ module Freefeed
         authenticated_request(:post, "/v1/attachments", options)
       end
 
+      def create_attachment_from(url:, **)
+        ::Freefeed::Downloader.new(url: url, **).call do |io, content_type|
+          response = create_attachment(io, content_type: content_type)
+          response.parse.fetch("attachments").fetch("id")
+        end
+      end
+
       private
 
       def file(source, content_type)

--- a/lib/freefeed/v2/timelines.rb
+++ b/lib/freefeed/v2/timelines.rb
@@ -31,8 +31,8 @@ module Freefeed
       private
 
       def request_timeline(path, offset)
-        params = offset.positive? ? {json: {offset: offset}} : {}
-        authenticated_request(:get, "/v2/timelines/#{path}", params)
+        payload = offset.positive? ? {json: {offset: offset}} : {}
+        authenticated_request(:get, "/v2/timelines/#{path}", payload)
       end
     end
   end

--- a/spec/lib/freefeed/authenticated_request_spec.rb
+++ b/spec/lib/freefeed/authenticated_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Freefeed::Request do
+RSpec.describe Freefeed::AuthenticatedRequest do
   let(:client) do
     Freefeed::Client.new(
       token: "TEST_TOKEN",
@@ -16,8 +16,8 @@ RSpec.describe Freefeed::Request do
           .with(
             body: {payload: "data"}.to_json,
             headers: {
+              "Authorization" => "Bearer TEST_TOKEN",
               "Content-Type" => "application/json; charset=utf-8",
-              "Host" => "example.com",
               "User-Agent" => "feeder"
             }
           )
@@ -38,20 +38,6 @@ RSpec.describe Freefeed::Request do
         expected = {"response" => "payload"}
 
         assert_equal expected, actual
-      end
-    end
-
-    context "when the response is unsuccessful" do
-      it "raises an error for unsuccessful response" do
-        stub_request(:get, "https://example.com/test").to_return(status: 404)
-
-        request = described_class.new(
-          client: client,
-          request_method: :get,
-          path: "/test"
-        )
-
-        expect { request.perform }.to raise_error(Freefeed::Error::NotFound)
       end
     end
   end

--- a/spec/lib/freefeed/downloader_spec.rb
+++ b/spec/lib/freefeed/downloader_spec.rb
@@ -1,5 +1,1 @@
 require "rails_helper"
-
-RSpec.describe Freefeed::Downloader do
-  # TBD
-end

--- a/spec/lib/freefeed/downloader_spec.rb
+++ b/spec/lib/freefeed/downloader_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Freefeed::Downloader do
+  # TBD
+end

--- a/spec/services/batch_publisher_spec.rb
+++ b/spec/services/batch_publisher_spec.rb
@@ -1,5 +1,1 @@
 require "rails_helper"
-
-RSpec.describe BatchPublisher do
-  # TBD
-end

--- a/spec/services/batch_publisher_spec.rb
+++ b/spec/services/batch_publisher_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe BatchPublisher do
+  # TBD
+end

--- a/spec/services/post_publisher_spec.rb
+++ b/spec/services/post_publisher_spec.rb
@@ -1,5 +1,1 @@
 require "rails_helper"
-
-RSpec.describe PostPublisher do
-  # TBD
-end

--- a/spec/services/post_publisher_spec.rb
+++ b/spec/services/post_publisher_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe PostPublisher do
+  # TBD
+end


### PR DESCRIPTION
## Summary

- Implement Publisher service.
- Refactor Freefeed API wrapper.

## Changes

- Use consistent terminology in the Freefeed API wrapper.
- Add credentials accessors to the Feeder configuration.
- Move Freefeed-specific `Downloader` service to the API wrapper namespace.
- Use HTTP client as a parameter instead of passing the client params separately.
- Improve terminology.
- Improve test coverage.