### PR TITLE
Update status page URL from frf.im to status.fffeeder.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ If you have a question or want to report a bug, please open an issue.
 
 ## References
 
-- Status page: https://frf.im
+- Status page: https://status.fffeeder.com
 - Project wiki: https://github.com/dreikanter/feeder/wiki
 - Service account on Freefeed: https://freefeed.net/feeder

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,7 @@ module Feeder
     # config.eager_load_paths += config.root.join('lib')
 
     config.hosts << "feeder.local"
-    config.hosts << "frf.im"
+    config.hosts << "status.fffeeder.com"
     config.hosts << "localhost"
 
     config.generators do |generate|


### PR DESCRIPTION
## Summary
Updates all references to the status page URL from the short domain `frf.im` to the new domain `status.fffeeder.com`.

## Changes
- Updated status page URL in README.md documentation
- Updated allowed host configuration in Rails application settings to reflect the new domain

## Details
This change ensures that the application's host allowlist and public documentation are aligned with the new status page domain. The Rails `config.hosts` setting is updated to permit requests to the new domain, which is important for security and proper request routing.
