### PR TITLE
Add feed smoke-test rake task and CheckFeed service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-debug.log*
 .env
 
 app/assets/builds
+
+# Redis persistence dump
+dump.rdb

--- a/app/services/check_feed.rb
+++ b/app/services/check_feed.rb
@@ -1,0 +1,71 @@
+# Runs the loader → processor → normalizer pipeline for a single feed
+# without writing any posts or calling the Freefeed API.
+#
+# Usage:
+#   result = CheckFeed.call(feed)
+#   result.ok?          # => true / false
+#   result.entity_count # => Integer
+#   result.error_message # => String or nil
+class CheckFeed
+  include Callee
+
+  param :feed
+
+  Result = Data.define(
+    :feed_name,
+    :loader,
+    :processor,
+    :normalizer,
+    :entity_count,
+    :validation_error_tally,
+    :error_message
+  )
+
+  def call
+    loader_klass = feed.loader_class
+    processor_klass = feed.processor_class
+    normalizer_klass = feed.normalizer_class
+
+    content = loader_klass.new(feed).content
+    entities = processor_klass.new(content: content, feed: feed).process
+    limit = feed.import_limit_or_default
+    entities = entities.take(limit) if limit.positive?
+
+    normalized = entities.filter_map do |entity|
+      normalizer_klass.call(entity)
+    rescue StandardError
+      nil
+    end
+
+    build_ok_result(normalized)
+  rescue StandardError => e
+    build_error_result(e)
+  end
+
+  private
+
+  def build_ok_result(normalized)
+    tally = normalized.flat_map(&:validation_errors).tally
+    Result.new(
+      feed_name: feed.name,
+      loader: feed.loader,
+      processor: feed.processor,
+      normalizer: feed.normalizer,
+      entity_count: normalized.size,
+      validation_error_tally: tally,
+      error_message: nil
+    )
+  end
+
+  def build_error_result(error)
+    Result.new(
+      feed_name: feed.name,
+      loader: feed.loader,
+      processor: feed.processor,
+      normalizer: feed.normalizer,
+      entity_count: 0,
+      validation_error_tally: {},
+      error_message: error.message.truncate(200)
+    )
+  end
+end

--- a/app/services/check_feed.rb
+++ b/app/services/check_feed.rb
@@ -22,27 +22,35 @@ class CheckFeed
   )
 
   def call
-    loader_klass = feed.loader_class
-    processor_klass = feed.processor_class
-    normalizer_klass = feed.normalizer_class
-
-    content = loader_klass.new(feed).content
-    entities = processor_klass.new(content: content, feed: feed).process
-    limit = feed.import_limit_or_default
-    entities = entities.take(limit) if limit.positive?
-
-    normalized = entities.filter_map do |entity|
-      normalizer_klass.call(entity)
-    rescue StandardError
-      nil
-    end
-
-    build_ok_result(normalized)
+    build_ok_result(normalize(load_entities))
   rescue StandardError => e
     build_error_result(e)
   end
 
   private
+
+  def load_entities
+    entities = process(load_content)
+    limit = feed.import_limit_or_default
+    limit.positive? ? entities.take(limit) : entities
+  end
+
+  def load_content
+    feed.loader_class.new(feed).content
+  end
+
+  def process(content)
+    feed.processor_class.new(content: content, feed: feed).process
+  end
+
+  def normalize(entities)
+    normalizer_klass = feed.normalizer_class
+    entities.filter_map do |entity|
+      normalizer_klass.call(entity)
+    rescue StandardError
+      nil
+    end
+  end
 
   def build_ok_result(normalized)
     tally = normalized.flat_map(&:validation_errors).tally

--- a/lib/tasks/check_feeds.rake
+++ b/lib/tasks/check_feeds.rake
@@ -1,0 +1,92 @@
+# Smoke-test all enabled feeds against live sources.
+#
+# Runs the full loader → processor → normalizer pipeline for every enabled
+# feed without writing posts or touching the Freefeed API.
+#
+# Prerequisites:
+#   1. A running PostgreSQL database (RAILS_ENV=development or test).
+#   2. For nitter feeds: run `rake feeder:import_nitter_instances` first so
+#      that ServiceInstance records exist.
+#
+# Usage:
+#   bundle exec rake feeder:check              # check all enabled feeds
+#   bundle exec rake feeder:check[feed-name]   # check one specific feed
+#
+namespace :feeder do
+  desc "Smoke-test enabled feeds without posting (loader+processor+normalizer only)"
+  task :check, [:feed_name] => :environment do |_task, args|
+    FeedsConfiguration.sync
+
+    feeds =
+      if args[:feed_name].present?
+        [Feed.enabled.find_by!(name: args[:feed_name])]
+      else
+        Feed.enabled.order(:name)
+      end
+
+    puts "\nChecking #{feeds.size} #{"feed".pluralize(feeds.size)}...\n\n"
+
+    results = feeds.map do |feed|
+      result = CheckFeed.call(feed)
+      print_feed_result(result)
+      result
+    end
+
+    print_summary(results)
+
+    exit 1 if results.any? { |r| r.error_message }
+  end
+end
+
+def print_feed_result(result)
+  pipeline = "#{result.loader}/#{result.processor}/#{result.normalizer}"
+
+  if result.error_message
+    status = red("✗")
+    detail = red("FAILED: #{result.error_message}")
+  elsif result.entity_count.zero?
+    status = yellow("⚠")
+    detail = yellow("0 entities")
+  else
+    status = green("✓")
+    parts = ["#{result.entity_count} #{"entity".pluralize(result.entity_count)}"]
+    unless result.validation_error_tally.empty?
+      tally_str = result.validation_error_tally.map { |k, v| "#{k}: #{v}" }.join(", ")
+      parts << dim("[#{tally_str}]")
+    end
+    detail = parts.join("  ")
+  end
+
+  puts "  #{status}  #{result.feed_name.ljust(30)} #{dim(pipeline.ljust(36))} #{detail}"
+end
+
+def print_summary(results)
+  ok = results.count { |r| r.error_message.nil? && r.entity_count.positive? }
+  warned = results.count { |r| r.error_message.nil? && r.entity_count.zero? }
+  failed = results.count { |r| r.error_message }
+
+  puts "\n#{"─" * 78}\n"
+  parts = ["Checked #{results.size} #{"feed".pluralize(results.size)}:"]
+  parts << green("#{ok} ok") if ok.positive?
+  parts << yellow("#{warned} warned") if warned.positive?
+  parts << red("#{failed} failed") if failed.positive?
+  puts parts.join("  ")
+
+  if failed.positive?
+    puts "\nFailed feeds:"
+    results.select { |r| r.error_message }.each do |r|
+      puts "  #{red(r.feed_name)}: #{r.error_message}"
+    end
+  end
+
+  puts
+end
+
+def green(str) = colorize(str, 32)
+def yellow(str) = colorize(str, 33)
+def red(str) = colorize(str, 31)
+def dim(str) = colorize(str, 2)
+
+def colorize(str, code)
+  $stdout.tty? ? "\e[#{code}m#{str}\e[0m" : str
+end


### PR DESCRIPTION
## Summary

Adds a new rake task `feeder:check` that smoke-tests all enabled feeds by running them through the full loader → processor → normalizer pipeline without writing posts or calling the Freefeed API. This allows developers to validate feed configurations and catch issues early.

### Changes

- **`lib/tasks/check_feeds.rake`**: New rake task that:
  - Checks all enabled feeds or a specific feed by name
  - Runs the complete pipeline (loader, processor, normalizer) for each feed
  - Displays results with color-coded status (✓ ok, ⚠ warned, ✗ failed)
  - Shows entity counts and validation error tallies
  - Exits with code 1 if any feeds fail
  - Requires PostgreSQL and (for nitter feeds) pre-imported ServiceInstance records

- **`app/services/check_feed.rb`**: New service class that:
  - Encapsulates the pipeline execution for a single feed
  - Catches and reports errors gracefully
  - Collects validation errors from normalized entities
  - Returns a structured Result object with feed metadata and statistics

- **`.gitignore`**: Added `dump.rdb` (Redis persistence file)

### Usage

```bash
bundle exec rake feeder:check              # check all enabled feeds
bundle exec rake feeder:check[feed-name]   # check one specific feed
```

## Checklist

- [x] Change is internal-only (development/testing utility)
