### PR TITLE
Disable newflux feed

### DIFF
--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -316,6 +316,8 @@
   import_limit: 2
 
 - name: "newflux"
+  enabled: false
+  disabling_reason: "The original UX/UI design blog stopped publishing years ago and the domain has since been repurposed for unrelated content; the feed endpoint returns HTTP 403."
   url: "https://newflux.fr/feed/"
   loader: "http"
   processor: "feedjira"


### PR DESCRIPTION
## Summary

- Disable the `newflux` feed in `config/feeds.yml`. The original UX/UI design blog stopped publishing years ago (the public mirror at rssing.com shows the last article in late 2015) and the `newflux.fr` domain has since been repurposed for unrelated content (currently a French online-casino landing page). The feed endpoint `https://newflux.fr/feed/` now returns HTTP 403 (Cloudflare).
- This was the source of the unresolved Honeybadger fault `HttpLoader::Error: HTTP request failed` (~127 notices since the 2026-05-06 deploy, recurrence of the historically resolved fault #98758974 with ~18k notices).

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #626