### PR TITLE
Raise typed error with status and URL on nitter HTTP failure

### DIFF
--- a/app/loaders/nitter_loader.rb
+++ b/app/loaders/nitter_loader.rb
@@ -1,6 +1,8 @@
 class NitterLoader < BaseLoader
   include HttpClient
 
+  Error = Class.new(StandardError)
+
   # :reek:TooManyStatements
   def content
     pick_service_instance
@@ -17,7 +19,8 @@ class NitterLoader < BaseLoader
   end
 
   def load_content
-    raise unless response.status.success?
+    status = response.status
+    raise Error, "nitter returned #{status} for #{nitter_rss_url}" unless status.success?
     response.to_s
   rescue StandardError
     register_error


### PR DESCRIPTION
## Summary

- Replace bare `raise` in `NitterLoader#load_content` with a typed `NitterLoader::Error` carrying the HTTP status and the nitter RSS URL, so failures group under a named class in Honeybadger instead of as opaque `RuntimeError`s with no message.
