### PR TITLE
Retry transient HTTP errors in feed loaders

### DIFF
--- a/app/loaders/http_loader.rb
+++ b/app/loaders/http_loader.rb
@@ -11,6 +11,6 @@ class HttpLoader < BaseLoader
   private
 
   def response
-    @response ||= http.get(feed.url)
+    @response ||= http_get(feed.url)
   end
 end

--- a/app/loaders/nitter_loader.rb
+++ b/app/loaders/nitter_loader.rb
@@ -39,7 +39,7 @@ class NitterLoader < BaseLoader
   end
 
   def response
-    @response ||= http.get(nitter_rss_url.to_s)
+    @response ||= http_get(nitter_rss_url.to_s)
   end
 
   def nitter_rss_url

--- a/app/services/reddit_points_fetcher.rb
+++ b/app/services/reddit_points_fetcher.rb
@@ -20,7 +20,7 @@ class RedditPointsFetcher
   # :reek:TooManyStatements
   def page_content
     service_instance.update!(used_at: Time.current, usages_count: service_instance.usages_count.succ)
-    response = http.get(libreddit_url)
+    response = http_get(libreddit_url)
     raise unless response.status.success?
     response.to_s
   rescue StandardError

--- a/app/support/http_client.rb
+++ b/app/support/http_client.rb
@@ -1,7 +1,11 @@
 module HttpClient
   HTTP_CLIENT_MAX_HOPS = 3
+  HTTP_CLIENT_TIMEOUT = 15
+  HTTP_CLIENT_RETRY_DELAY = 0.5
+  HTTP_CLIENT_RETRYABLE_ERRORS = [HTTP::TimeoutError, HTTP::ConnectionError].freeze
 
-  private_constant :HTTP_CLIENT_MAX_HOPS
+  private_constant :HTTP_CLIENT_MAX_HOPS, :HTTP_CLIENT_TIMEOUT,
+    :HTTP_CLIENT_RETRY_DELAY, :HTTP_CLIENT_RETRYABLE_ERRORS
 
   # :reek:UtilityFunction
   def http
@@ -9,6 +13,16 @@ module HttpClient
       HTTP::Options.register_feature(:request_tracking, RequestTracking)
     end
 
-    HTTP.use(:request_tracking).follow(max_hops: HTTP_CLIENT_MAX_HOPS).timeout(5)
+    HTTP.use(:request_tracking).follow(max_hops: HTTP_CLIENT_MAX_HOPS).timeout(HTTP_CLIENT_TIMEOUT)
+  end
+
+  # :reek:UtilityFunction
+  def http_get(url, attempts: 2)
+    attempts.times do |i|
+      return http.get(url)
+    rescue *HTTP_CLIENT_RETRYABLE_ERRORS
+      raise if i == attempts - 1
+      sleep(HTTP_CLIENT_RETRY_DELAY)
+    end
   end
 end

--- a/app/support/http_client.rb
+++ b/app/support/http_client.rb
@@ -18,10 +18,10 @@ module HttpClient
 
   # :reek:UtilityFunction
   def http_get(url, attempts: 2)
-    attempts.times do |i|
+    attempts.times do |attempt|
       return http.get(url)
     rescue *HTTP_CLIENT_RETRYABLE_ERRORS
-      raise if i == attempts - 1
+      raise if attempt == attempts - 1
       sleep(HTTP_CLIENT_RETRY_DELAY)
     end
   end

--- a/spec/support/http_client_spec.rb
+++ b/spec/support/http_client_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe HttpClient do
+  subject(:client) { Class.new { include HttpClient }.new }
+
+  let(:url) { "https://example.com/feed" }
+  let(:body) { "BANANA" }
+
+  before { allow(client).to receive(:sleep) }
+
+  describe "#http_get" do
+    it "returns the response on success" do
+      stub_request(:get, url).to_return(body: body)
+      expect(client.http_get(url).to_s).to eq(body)
+    end
+
+    it "retries once on HTTP::TimeoutError and succeeds" do
+      stub_request(:get, url).to_raise(HTTP::TimeoutError).then.to_return(body: body)
+      expect(client.http_get(url).to_s).to eq(body)
+    end
+
+    it "retries once on HTTP::ConnectionError and succeeds" do
+      stub_request(:get, url).to_raise(HTTP::ConnectionError).then.to_return(body: body)
+      expect(client.http_get(url).to_s).to eq(body)
+    end
+
+    it "raises after exhausting retries" do
+      stub_request(:get, url).to_raise(HTTP::TimeoutError)
+      expect { client.http_get(url) }.to raise_error(HTTP::TimeoutError)
+    end
+
+    it "does not retry on non-retryable errors" do
+      stub_request(:get, url).to_raise(StandardError)
+      expect { client.http_get(url) }.to raise_error(StandardError)
+      expect(WebMock).to have_requested(:get, url).once
+    end
+
+    it "does not retry on HTTP error status responses" do
+      stub_request(:get, url).to_return(status: 500)
+      expect(client.http_get(url).status.code).to eq(500)
+      expect(WebMock).to have_requested(:get, url).once
+    end
+
+    it "honors the attempts argument" do
+      stub_request(:get, url).to_raise(HTTP::TimeoutError).then.to_raise(HTTP::TimeoutError).then.to_return(body: body)
+      expect(client.http_get(url, attempts: 3).to_s).to eq(body)
+    end
+  end
+end

--- a/spec/support/http_client_spec.rb
+++ b/spec/support/http_client_spec.rb
@@ -1,12 +1,11 @@
 require "rails_helper"
 
 RSpec.describe HttpClient do
-  subject(:client) { Class.new { include HttpClient }.new }
-
+  let(:client) { Class.new { include HttpClient }.new }
   let(:url) { "https://example.com/feed" }
   let(:body) { "BANANA" }
 
-  before { allow(client).to receive(:sleep) }
+  before { stub_const("HttpClient::HTTP_CLIENT_RETRY_DELAY", 0) }
 
   describe "#http_get" do
     it "returns the response on success" do


### PR DESCRIPTION
## Summary

- Bump the `HttpClient` global timeout from 5s to 15s and add a `http_get(url, attempts:)` helper that retries idempotent GETs once on `HTTP::TimeoutError` / `HTTP::ConnectionError` with a 0.5s backoff.
- Switch the three known-noisy feed-fetch call sites — `HttpLoader`, `NitterLoader`, `RedditPointsFetcher` — to `http_get`.
- Targets the transient one-off `HTTP::TimeoutError` notices we see in Honeybadger (e.g. fault #130285989 on `lobsters-ruby`, where the upstream responds in ~0.4s and the failure was a single network blip against the tight 5s budget).

The retry covers idempotent GET only and is opt-in via `http_get` — chained-style call sites (`http.get(...).status.success?`, health checks, etc.) keep their current single-shot semantics, so availability checkers continue to detect outages instead of masking them.

## References

- Closes #629
- Closes #630