### PR TITLE
Switch litterbox feed to FeedBurner mirror and refresh daily

### DIFF
--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -712,11 +712,11 @@
   import_limit: 2
 
 - name: "litterbox"
-  url: "https://www.litterboxcomics.com/feed/"
+  url: "https://feeds.feedburner.com/litterboxcomics/yS3QAzAMEMP"
   loader: "http"
   processor: "feedjira"
   normalizer: "litterbox"
-  refresh_interval: 3600
+  refresh_interval: 86400
   import_limit: 2
 
 - name: "lizandmollie"


### PR DESCRIPTION
## Summary

- The upstream `https://www.litterboxcomics.com/feed/` is now gated by SiteGround's SG-Captcha. Every request returns `HTTP 202` with an HTML challenge page instead of feed XML, which is what makes feedjira raise `No valid parser for XML` (#625).
- Switch the loader URL to the site's FeedBurner mirror (`https://feeds.feedburner.com/litterboxcomics/yS3QAzAMEMP`), which serves valid RSS 2.0 (`Content-Type: text/xml`) and contains the same items linking back to `litterboxcomics.com`, so the existing `litterbox` normalizer keeps working unchanged.
- Drop the refresh interval from 1h to 24h — the comic publishes weekly and FeedBurner is best treated as a low-traffic mirror.

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #625
