### PR TITLE
Disable shvarz feed

### DIFF
--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -638,6 +638,8 @@
   after: "2021-01-06T12:00:00+00:00"
 
 - name: "shvarz"
+  enabled: false
+  disabling_reason: "This journal has been deleted"
   url: "https://shvarz.livejournal.com/data/rss"
   loader: "http"
   processor: "rss"


### PR DESCRIPTION
## Summary

- Mark `shvarz` LiveJournal feed as disabled with reason "This journal has been deleted".

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #628
