### PR TITLE
Disable explosm-comics feed

### DIFF
--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -119,6 +119,8 @@
   import_limit: 2
 
 - name: "explosm-comics"
+  enabled: false
+  disabling_reason: "FeedBurner was shut down by Google in 2023"
   url: "https://feeds.feedburner.com/Explosm"
   loader: "http"
   processor: "rss"

--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -120,7 +120,6 @@
 
 - name: "explosm-comics"
   enabled: false
-  disabling_reason: "FeedBurner was shut down by Google in 2023"
   url: "https://feeds.feedburner.com/Explosm"
   loader: "http"
   processor: "rss"


### PR DESCRIPTION
## Summary

- Mark `explosm-comics` feed as disabled with reason "FeedBurner was shut down by Google in 2023".

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #623
