### PR TITLE
Disable agavr-today feed due to inactive source

### DIFF
--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -199,6 +199,8 @@
   import_limit: 2
 
 - name: "agavr-today"
+  enabled: false
+  disabling_reason: "tele.ga feed is inactive"
   url: "https://tele.ga/agavr_today/rss/"
   loader: "http"
   processor: "rss"


### PR DESCRIPTION
## Summary

Disable the "agavr-today" feed in the feeds configuration as the upstream source (tele.ga) is no longer active.

## References

- Closes #622
