### PR TITLE
Unescape HTML entities in Atom feed titles

### DIFF
--- a/app/normalizers/atom_normalizer.rb
+++ b/app/normalizers/atom_normalizer.rb
@@ -8,6 +8,7 @@ class AtomNormalizer < BaseNormalizer
   end
 
   def text
-    content.title.try(:content)
+    title = content.title.try(:content)
+    title && CGI.unescapeHTML(title)
   end
 end

--- a/spec/fixtures/files/feeds/github_blog/feed.xml
+++ b/spec/fixtures/files/feeds/github_blog/feed.xml
@@ -51,4 +51,20 @@
           <content type="html" xml:base="https://github.blog/2023-07-27-scaling-merge-ort-across-github/"><![CDATA[<p>Content</p>]]></content>
 
       </entry>
+    <entry>
+    <author>
+      <name>Author</name>
+          </author>
+
+    <title type="html"><![CDATA[Dungeons &amp; Desktops: Building a procedurally generated roguelike with GitHub Copilot CLI]]></title>
+    <link rel="alternate" type="text/html" href="https://github.blog/ai-and-ml/github-copilot/dungeons-desktops-building-a-procedurally-generated-roguelike-with-github-copilot-cli/" />
+
+    <id>https://github.blog/?p=99999</id>
+    <updated>2023-07-26T16:03:15Z</updated>
+    <published>2023-07-26T16:00:54Z</published>
+    <summary type="html"><![CDATA[Summary.]]></summary>
+
+          <content type="html" xml:base="https://github.blog/ai-and-ml/github-copilot/dungeons-desktops-building-a-procedurally-generated-roguelike-with-github-copilot-cli/"><![CDATA[<p>Content</p>]]></content>
+
+      </entry>
   </feed>

--- a/spec/fixtures/files/feeds/github_blog/normalized.json
+++ b/spec/fixtures/files/feeds/github_blog/normalized.json
@@ -30,5 +30,21 @@
     "validation_errors": [
 
     ]
+  },
+  {
+    "feed_id": 17677,
+    "uid": "https://github.blog/ai-and-ml/github-copilot/dungeons-desktops-building-a-procedurally-generated-roguelike-with-github-copilot-cli/",
+    "link": "https://github.blog/ai-and-ml/github-copilot/dungeons-desktops-building-a-procedurally-generated-roguelike-with-github-copilot-cli/",
+    "published_at": "2023-07-26 16:00:54 +0000",
+    "text": "Dungeons & Desktops: Building a procedurally generated roguelike with GitHub Copilot CLI - !https://github.blog/ai-and-ml/github-copilot/dungeons-desktops-building-a-procedurally-generated-roguelike-with-github-copilot-cli/",
+    "attachments": [
+
+    ],
+    "comments": [
+      "Content"
+    ],
+    "validation_errors": [
+
+    ]
   }
 ]

--- a/spec/normalizers/github_blog_normalizer_spec.rb
+++ b/spec/normalizers/github_blog_normalizer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GithubBlogNormalizer do
         processor: "atom",
         normalizer: "github_blog",
         url: "https://github.com/blog/all.atom",
-        import_limit: 2
+        import_limit: 3
       )
     end
 


### PR DESCRIPTION
## Summary

- Unescape HTML entities in Atom feed entry titles using `CGI.unescapeHTML`
- Update test fixtures to include a new feed entry with HTML entities in the title
- Increase import limit in test from 2 to 3 to accommodate the new test entry

## References

- Closes #537
