### PR TITLE
Validate Nitter response content to prune broken instances

### DIFF
--- a/app/loaders/nitter_loader.rb
+++ b/app/loaders/nitter_loader.rb
@@ -18,10 +18,12 @@ class NitterLoader < BaseLoader
     )
   end
 
+  # :reek:TooManyStatements
   def load_content
     status = response.status
     raise Error, "nitter returned #{status} for #{nitter_rss_url}" unless status.success?
-    response.to_s
+    raise Error, "nitter returned unparseable content for #{nitter_rss_url}" unless FeedContent.parseable?(body)
+    body
   rescue StandardError
     register_error
     raise
@@ -30,7 +32,7 @@ class NitterLoader < BaseLoader
   def register_error
     Honeybadger.context(
       nitter_loader: {
-        response: response.as_json,
+        response: {status: response.status.to_s, body: body},
         service_instance: service_instance.as_json
       }
     )
@@ -40,6 +42,10 @@ class NitterLoader < BaseLoader
 
   def response
     @response ||= http_get(nitter_rss_url.to_s)
+  end
+
+  def body
+    @body ||= response.to_s
   end
 
   def nitter_rss_url

--- a/app/services/nitter_instance_availability_checker.rb
+++ b/app/services/nitter_instance_availability_checker.rb
@@ -2,7 +2,8 @@ class NitterInstanceAvailabilityChecker < ServiceInstanceAvailabilityChecker
   include HttpClient
 
   def available?
-    http.get(sample_rss_url).status.success?
+    response = http.get(sample_rss_url)
+    response.status.success? && FeedContent.parseable?(response.to_s)
   rescue StandardError
     false
   end

--- a/app/support/feed_content.rb
+++ b/app/support/feed_content.rb
@@ -1,0 +1,11 @@
+class FeedContent
+  # @return [Boolean] true when the content can be parsed as a feed. A Nitter
+  #   instance that returns an HTML error or rate-limit page with a 2xx status
+  #   fails this check, which lets callers treat it as unavailable.
+  def self.parseable?(content)
+    Feedjira.parse(content.to_s).entries
+    true
+  rescue StandardError
+    false
+  end
+end

--- a/config/feeds.yml
+++ b/config/feeds.yml
@@ -422,6 +422,9 @@
     ignore_retweets: true
 
 - name: "extrafabulous"
+  enabled: false
+  disabling_reason: "Twitter/X account inactive as a feed source since ~2025; creator active on Instagram and in print"
+  source_url: "https://x.com/extrafabulous"
   loader: "nitter"
   processor: "nitter"
   normalizer: "nitter"
@@ -465,6 +468,9 @@
   after: "2021-01-06T12:00:00+00:00"
 
 - name: "jakelikesonions"
+  enabled: false
+  disabling_reason: "Twitter/X account inactive since 2019; webcomic discontinued"
+  source_url: "https://x.com/jakelikesonions"
   loader: "nitter"
   processor: "nitter"
   normalizer: "nitter"
@@ -477,6 +483,9 @@
     ignore_retweets: true
 
 - name: "catscafe"
+  enabled: false
+  disabling_reason: "Twitter/X account inactive since ~2022; creator moved to GoComics/Webtoon/Instagram"
+  source_url: "https://x.com/CatsCafeComics"
   loader: "nitter"
   processor: "nitter"
   normalizer: "nitter"
@@ -521,6 +530,9 @@
   after: "2021-01-06T12:00:00+00:00"
 
 - name: "nathanwpyle"
+  enabled: false
+  disabling_reason: "Twitter/X account inactive since ~2024; creator active on Instagram/Threads"
+  source_url: "https://x.com/nathanwpyle"
   loader: "nitter"
   processor: "nitter"
   normalizer: "nitter"

--- a/spec/loaders/nitter_loader_spec.rb
+++ b/spec/loaders/nitter_loader_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NitterLoader do
   subject(:load_content) { described_class.new(feed).content }
 
   let(:feed) { build(:feed, options: {"twitter_user" => "username"}) }
-  let(:body) { "CONTENT BODY" }
+  let(:body) { file_fixture("feeds/nitter/rss.xml").read }
 
   let(:service_instance) do
     create(
@@ -82,6 +82,21 @@ RSpec.describe NitterLoader do
     def expect_failed_loader_to(do_things)
       stub_request(:get, nitter_url).to_return(status: 404)
       expect { load_content }.to raise_error(StandardError).and(do_things)
+    end
+  end
+
+  context "when instance returns unparseable content with a success status" do
+    before { service_instance }
+
+    it "raises an error" do
+      stub_request(:get, nitter_url).to_return(status: 200, body: "<html>rate limited</html>")
+      expect { load_content }.to raise_error(NitterLoader::Error)
+    end
+
+    it "registers a service instance error" do
+      stub_request(:get, nitter_url).to_return(status: 200, body: "<html>rate limited</html>")
+      expect { load_content }.to raise_error(StandardError)
+        .and(change { service_instance.reload.state }.from("enabled").to("failed"))
     end
   end
 end

--- a/spec/services/nitter_instance_availability_checker_spec.rb
+++ b/spec/services/nitter_instance_availability_checker_spec.rb
@@ -4,15 +4,22 @@ RSpec.describe NitterInstanceAvailabilityChecker do
   subject(:result) { described_class.new(service_instance).available? }
 
   let(:service_instance) { create(:service_instance, service_type: "nitter", state: :enabled) }
+  let(:feed_content) { file_fixture("feeds/nitter/rss.xml").read }
 
-  context "when instance is available" do
-    before { stub_instance_request.to_return(status: 200) }
+  context "when instance returns a parseable feed" do
+    before { stub_instance_request.to_return(status: 200, body: feed_content) }
 
     it { expect(result).to be_truthy }
   end
 
   context "when instance does not support RSS" do
     before { stub_instance_request.to_return(status: 404) }
+
+    it { expect(result).to be_falsey }
+  end
+
+  context "when instance returns unparseable content with a success status" do
+    before { stub_instance_request.to_return(status: 200, body: "<html>rate limited</html>") }
 
     it { expect(result).to be_falsey }
   end

--- a/spec/services/nitter_instances_pool_updater_spec.rb
+++ b/spec/services/nitter_instances_pool_updater_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NitterInstancesPoolUpdater do
     stub_request(:get, NitterInstancesFetcher::PUBLIC_INSTANCES_WIKI_PAGE_URL)
       .to_return(body: file_fixture("nitter_instances_wiki_page.html").read)
 
-    stub_request(:get, %r{/rss$}).to_return(status: 200)
+    stub_request(:get, %r{/rss$}).to_return(status: 200, body: file_fixture("feeds/nitter/rss.xml").read)
     service_call
   end
 

--- a/spec/support/feed_content_spec.rb
+++ b/spec/support/feed_content_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe FeedContent do
+  describe ".parseable?" do
+    subject(:parseable) { described_class.parseable?(content) }
+
+    context "with valid feed content" do
+      let(:content) { file_fixture("feeds/nitter/rss.xml").read }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with an HTML page" do
+      let(:content) { "<html><body>Instance has been rate limited</body></html>" }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "with empty content" do
+      let(:content) { "" }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "with nil content" do
+      let(:content) { nil }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the `Feedjira::NoParserAvailable` errors (538+ occurrences) affecting every Nitter-backed feed.

**Root cause:** the Nitter subsystem validated only HTTP status, never response content. A Nitter instance returning HTTP 200 with a non-RSS body (an HTML rate-limit/error page) passed both the availability check and the loader's status check. The HTML was then handed to `FeedjiraProcessor`, raising `NoParserAvailable`. Because the response was 2xx, `register_error` never fired, so the broken instance was never suspended — it stayed in the pool and corrupted ~1/N of *every* Nitter feed's pulls. This is why feeds like `neural-machine` got fresh posts when they drew a healthy instance but errored when they drew a poison one (instance-level, not account-level).

**Fix — validate that the response is actually a parseable feed, in both places:**
- `NitterInstanceAvailabilityChecker#available?` now requires the sample RSS to parse, so poison instances are marked `disabled` on pool refresh.
- `NitterLoader` now treats unparseable content as an instance error (`register_error` + raise `NitterLoader::Error`), so a poison instance that slips through gets suspended after `MAX_ERRORS` and the failure is correctly attributed and self-heals.
- New `FeedContent.parseable?` helper, shared by both.

Healthy instances keep serving the live feeds; broken ones get pruned.

**Also disables 4 inactive Nitter feeds.** Their X source accounts have produced no content for 16 months to 4 years (verified against freefeed cadence and source research): `catscafe`, `extrafabulous`, `jakelikesonions`, `nathanwpyle`. Each carries a `disabling_reason`. The live feeds (`neural-machine`, `warandpeas`, `yesbut`, `safelyendangered`) stay enabled; their 2h refresh interval is already well within Nitter rate limits.

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only <!-- no CHANGELOG.md in repo -->
