### PR TITLE
Stop reporting errors when no service instance is available

### DIFF
--- a/app/models/service_instance.rb
+++ b/app/models/service_instance.rb
@@ -1,6 +1,8 @@
 class ServiceInstance < ApplicationRecord
   include AASM
 
+  NoInstanceAvailableError = Class.new(StandardError)
+
   MAX_ERRORS = 3
 
   validates :service_type, :url, :errors_count, :total_errors_count, presence: true
@@ -49,7 +51,7 @@ class ServiceInstance < ApplicationRecord
   def self.pick!(required_type)
     operational.where(service_type: required_type).first!
   rescue ActiveRecord::RecordNotFound
-    raise "no available service instances of #{required_type} type"
+    raise NoInstanceAvailableError, "no available service instances of #{required_type} type"
   end
 
   def register_error

--- a/app/processors/reddit_processor.rb
+++ b/app/processors/reddit_processor.rb
@@ -29,6 +29,10 @@ class RedditProcessor < BaseProcessor
 
   def score(url)
     RedditPointsFetcher.new(url).points
+  rescue ServiceInstance::NoInstanceAvailableError
+    # NOTE: An empty Libreddit pool is an expected, recurring condition, so it
+    #  is swallowed silently rather than flooding error reports.
+    0
   rescue StandardError => e
     # NOTE: Individual post score fetching should not crash the processor,
     #  but they are getting reported to monitor Reddit availability

--- a/spec/processors/reddit_processor_spec.rb
+++ b/spec/processors/reddit_processor_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe RedditProcessor do
     expect(feed_entities).to be_empty
   end
 
+  it "ignores posts without reporting when no service instance is available" do
+    ServiceInstance.delete_all
+    allow(Honeybadger).to receive(:notify)
+    expect(feed_entities).to be_empty
+    expect(Honeybadger).not_to have_received(:notify)
+  end
+
   def feed_entities
     processor.new(content: content, feed: feed).process
   end


### PR DESCRIPTION
## Summary

- Reddit post-score fetching relies on a Libreddit instance pool that has decayed to effectively a single instance. Whenever that instance flaps (downtime or rate-limiting trips the error/suspend threshold), the pool has zero operational instances and `ServiceInstance.pick!` raises, flooding Honeybadger ([fault #130263597](https://app.honeybadger.io/projects/65419/faults/130263597), 5,243 notices) for what is an expected, recurring condition.
- `ServiceInstance.pick!` now raises a dedicated `ServiceInstance::NoInstanceAvailableError` instead of a bare `RuntimeError`, so callers can tell an empty pool apart from a genuine fetch failure.
- `RedditProcessor#score` rescues `NoInstanceAvailableError` and silently returns `0`. Real fetch errors (HTTP failures etc.) are still reported via `Honeybadger.notify`.

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only