### PR TITLE
Stop reporting external feed-source errors to Honeybadger

### DIFF
--- a/app/services/error_dumper.rb
+++ b/app/services/error_dumper.rb
@@ -11,9 +11,10 @@ class ErrorDumper
   option :target, optional: true, default: -> {}
   option :context, optional: true, default: -> { {} }
   option :message, optional: true, default: -> { exception.try(:message) || exception.to_s }
+  option :notify, optional: true, default: -> { true }
 
   def call
-    notify_honeybadger(exception, message)
+    notify_honeybadger(exception, message) if notify
     persist_error
   end
 

--- a/app/services/process_feed.rb
+++ b/app/services/process_feed.rb
@@ -1,6 +1,15 @@
 class ProcessFeed
   include Logging
 
+  # Failures rooted in the remote source (network, TLS, non-success responses)
+  # rather than a bug in our code. These are tracked locally but not reported
+  # to Honeybadger, where they would only add recurring noise.
+  SOURCE_ERRORS = [
+    HTTP::Error,
+    OpenSSL::SSL::SSLError,
+    HttpLoader::Error
+  ].freeze
+
   attr_reader :feed
 
   def initialize(feed)
@@ -66,7 +75,12 @@ class ProcessFeed
       exception: error,
       message: "Error processing feed",
       target: feed,
-      context: {feed_name: feed_name}
+      context: {feed_name: feed_name},
+      notify: !source_error?(error)
     )
+  end
+
+  def source_error?(error)
+    SOURCE_ERRORS.any? { |klass| error.is_a?(klass) }
   end
 end

--- a/app/support/http_client.rb
+++ b/app/support/http_client.rb
@@ -2,7 +2,11 @@ module HttpClient
   HTTP_CLIENT_MAX_HOPS = 3
   HTTP_CLIENT_TIMEOUT = 15
   HTTP_CLIENT_RETRY_DELAY = 0.5
-  HTTP_CLIENT_RETRYABLE_ERRORS = [HTTP::TimeoutError, HTTP::ConnectionError].freeze
+  HTTP_CLIENT_RETRYABLE_ERRORS = [
+    HTTP::TimeoutError,
+    HTTP::ConnectionError,
+    OpenSSL::SSL::SSLError
+  ].freeze
 
   private_constant :HTTP_CLIENT_MAX_HOPS, :HTTP_CLIENT_TIMEOUT,
     :HTTP_CLIENT_RETRY_DELAY, :HTTP_CLIENT_RETRYABLE_ERRORS

--- a/spec/services/error_dumper_spec.rb
+++ b/spec/services/error_dumper_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe ErrorDumper do
     expect(error.backtrace).to be_a(Array)
   end
 
+  it "notifies Honeybadger by default" do
+    expect(Honeybadger).to receive(:notify)
+    service.call
+  end
+
+  it "does not notify Honeybadger when notify is false" do
+    expect(Honeybadger).not_to receive(:notify)
+    service.call(notify: false)
+  end
+
+  it "still persists the error when notify is false" do
+    expect { service.call(notify: false) }.to change(Error, :count).by(1)
+  end
+
   def dump_sample_exception
     raise "sample exception"
   rescue StandardError

--- a/spec/services/process_feed_spec.rb
+++ b/spec/services/process_feed_spec.rb
@@ -3,6 +3,7 @@ require_relative "../support/factory_bot"
 require_relative "../support/faulty_loader"
 require_relative "../support/faulty_normalizer"
 require_relative "../support/faulty_processor"
+require_relative "../support/source_faulty_loader"
 require_relative "../support/test_loader"
 require_relative "../support/test_processor"
 require_relative "../support/test_normalizer"
@@ -38,6 +39,15 @@ RSpec.describe ProcessFeed do
     )
   end
 
+  let(:feed_with_source_error) do
+    create(
+      :feed,
+      loader: "source_faulty",
+      processor: "test",
+      normalizer: "test"
+    )
+  end
+
   it "increments error counters when loader fails" do
     expect { service.new(feed_with_faulty_loader).process }.to increment_error_counters(feed_with_faulty_loader)
   end
@@ -56,6 +66,20 @@ RSpec.describe ProcessFeed do
 
   it "does not create posts on normalization error" do
     expect { service.new(feed_with_faulty_normalizer).process }.not_to change(Post, :count)
+  end
+
+  it "dumps source errors locally" do
+    expect { service.new(feed_with_source_error).process }.to change { errors_count(feed_with_source_error) }.by(1)
+  end
+
+  it "does not notify Honeybadger for source errors" do
+    expect(Honeybadger).not_to receive(:notify)
+    service.new(feed_with_source_error).process
+  end
+
+  it "notifies Honeybadger for unexpected errors" do
+    expect(Honeybadger).to receive(:notify).at_least(:once)
+    service.new(feed_with_faulty_loader).process
   end
 
   def increment_error_counters(feed)

--- a/spec/support/http_client_spec.rb
+++ b/spec/support/http_client_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe HttpClient do
       expect(client.http_get(url).to_s).to eq(body)
     end
 
+    it "retries once on OpenSSL::SSL::SSLError and succeeds" do
+      stub_request(:get, url).to_raise(OpenSSL::SSL::SSLError).then.to_return(body: body)
+      expect(client.http_get(url).to_s).to eq(body)
+    end
+
     it "raises after exhausting retries" do
       stub_request(:get, url).to_raise(HTTP::TimeoutError)
       expect { client.http_get(url) }.to raise_error(HTTP::TimeoutError)

--- a/spec/support/source_faulty_loader.rb
+++ b/spec/support/source_faulty_loader.rb
@@ -1,0 +1,5 @@
+class SourceFaultyLoader < BaseLoader
+  def content
+    raise OpenSSL::SSL::SSLError, "SSL handshake failed"
+  end
+end


### PR DESCRIPTION
## Summary

- External feed-source failures (broken TLS, network errors, non-2xx responses) were being reported to Honeybadger on every pull, even though they are not code bugs and are already tracked locally in the `errors` table and per-feed counters. One dead source (`commitstrip`, failing its TLS handshake) generated 125 notices in 11 days — pure recurring noise that buries real bugs.
- Added a `notify:` option to `ErrorDumper` (default `true`). When `false`, it skips `Honeybadger.notify` but still persists the `Error` record, so local visibility is unchanged.
- `ProcessFeed` now classifies `HTTP::Error`, `OpenSSL::SSL::SSLError`, and `HttpLoader::Error` as source errors and dumps them with `notify: false`. Genuinely unexpected errors (parser bugs, `NoMethodError`, etc.) still report to Honeybadger.
- Added `OpenSSL::SSL::SSLError` to `HttpClient` retryable errors so a transient handshake blip gets one retry, like timeouts and connection errors.

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only